### PR TITLE
journal crash fixed

### DIFF
--- a/dashboard/controller/journal.js
+++ b/dashboard/controller/journal.js
@@ -122,7 +122,6 @@ function getActivities(req, res, callback) {
 			req.flash('errors', {
 				msg: common.l10n.get('ErrorCode'+body.code)
 			});
-			return res.redirect('/dashboard/journal');
 		}
 	})
 }
@@ -150,7 +149,6 @@ function getJournalEntries(req, res, query, callback) {
 			req.flash('errors', {
 				msg: common.l10n.get('ErrorCode'+body.code)
 			});
-			return res.redirect('/dashboard/journal');
 		}
 	})
 }
@@ -174,7 +172,6 @@ function getUsers(req, res, callback) {
 			req.flash('errors', {
 				msg: common.l10n.get('ErrorCode'+body.code)
 			});
-			return res.redirect('/dashboard/journal');
 		}
 	})
 }


### PR DESCRIPTION
app crashes on client reload of journal page as it did the activity page in #51 . It showed similar behaviour to the activity page crash .