### PR TITLE
UX improvement

### DIFF
--- a/dashboard/controller/classrooms.js
+++ b/dashboard/controller/classrooms.js
@@ -1,7 +1,7 @@
 // include libraries
 var request = require('request'),
 	moment = require('moment'),
-	dashboard = require('./dashboard')
+	dashboard = require('./dashboard'),
 	common = require('../helper/common'),
 	xocolors = require('../helper/xocolors')(),
 	emoji = require('../public/js/emoji');
@@ -97,7 +97,7 @@ exports.addClassroom = function(req, res) {
 					req.flash('success', {
 						msg: common.l10n.get('ClassroomCreated')
 					});
-					return res.redirect('/dashboard/classrooms/edit/' + body._id);
+					return res.redirect('/dashboard/classrooms/');
 				} else {
 					req.flash('errors', {
 						msg: common.l10n.get('ErrorCode'+body.code)
@@ -161,7 +161,7 @@ exports.editClassroom = function(req, res) {
 						req.flash('success', {
 							msg: common.l10n.get('ClassroomUpdated')
 						});
-						return res.redirect('/dashboard/classrooms/edit/' + req.params.classid);
+						return res.redirect('/dashboard/classrooms/');
 					} else {
 						req.flash('errors', {
 							msg: common.l10n.get('ErrorCode'+body.code)

--- a/dashboard/controller/users.js
+++ b/dashboard/controller/users.js
@@ -10,7 +10,7 @@ var request = require('request'),
 var ini = null;
 exports.init = function(settings) {
 	ini = settings;
-}
+};
 
 // main landing page
 exports.index = function(req, res) {
@@ -107,7 +107,7 @@ exports.addUser = function(req, res) {
 					req.flash('success', {
 						msg: common.l10n.get('UserCreated')
 					});
-					return res.redirect('/dashboard/users/edit/' + body._id);
+					return res.redirect('/dashboard/users/');
 				} else {
 					req.flash('errors', {
 						msg: common.l10n.get('ErrorCode'+body.code)
@@ -163,7 +163,7 @@ exports.editUser = function(req, res) {
 						req.flash('success', {
 							msg: common.l10n.get('UserUpdated')
 						});
-						return res.redirect('/dashboard/users/edit/' + req.params.uid);
+						return res.redirect('/dashboard/users/edit/');
 					} else {
 						req.flash('errors', {
 							msg: common.l10n.get('ErrorCode'+body.code)

--- a/dashboard/views/classrooms.ejs
+++ b/dashboard/views/classrooms.ejs
@@ -74,12 +74,12 @@
                                           <td><%= moment(data.classrooms[i].timestamp).calendar() %></td>
                                           <td>
                                               <% if(Array.isArray(data.classrooms[i].students) && data.classrooms[i].students.length > 0) { %>
-                                                  <a title="View Students" href="users?role=student&classid=<%- data.classrooms[i].students.join(',') %>"><span class="student-icon"></span></a>
+                                                  <a title="View Students" href="/dashboard/users?role=student&classid=<%- data.classrooms[i].students.join(',') %>"><span class="student-icon"></span></a>
                                               <% } else { %>
                                                   <a title="View Students" style="pointer-events: none;"><span class="student-icon" style="opacity: 0.4;"></span></a>
                                               <% } %>
-                                              <a title="Edit Classroom" href="classrooms/edit/<%= data.classrooms[i]._id %>"><i class="material-icons text-muted">edit</i></a>
-                                              <a title="Delete Classroom" href="classrooms/delete/<%= data.classrooms[i]._id %>" onclick="return confirm(document.webL10n.get('DoYouWantDeleteClassroom', {classroom:'<%= data.classrooms[i].name %>'}))"><i class="material-icons text-muted">delete_forever</i></a>
+                                              <a title="Edit Classroom" href="/dashboard/classrooms/edit/<%= data.classrooms[i]._id %>"><i class="material-icons text-muted">edit</i></a>
+                                              <a title="Delete Classroom" href="/dashboard/classrooms/delete/<%= data.classrooms[i]._id %>" onclick="return confirm(document.webL10n.get('DoYouWantDeleteClassroom', {classroom:'<%= data.classrooms[i].name %>'}))"><i class="material-icons text-muted">delete_forever</i></a>
                                           </td>
                                       </tr>
                                     <% } %>

--- a/dashboard/views/users.ejs
+++ b/dashboard/views/users.ejs
@@ -113,9 +113,9 @@
                                               <td><%= data.users[i].role %></td>
                                               <td><%= moment(data.users[i].timestamp).calendar() %></td>
                                               <td>
-                                                                                          <a data-l10n-id="seeJournalEntries" title="See Journal Entries" href="journal/<%= data.users[i].private_journal %>?uid=<%= data.users[i]._id %>&type=private"><span class="journal-icon2"></span></a>
-                                                <a data-l10n-id="editUser" title="Edit User" href="users/edit/<%= data.users[i]._id %>"><i class="material-icons text-muted">edit</i></a>
-                                                <a data-l10n-id="deleteUser" title="Delete User" href="users/delete/<%= data.users[i]._id %>" onclick="return confirm(document.webL10n.get('DoYouWantDeleteUser',{user:'<%= data.users[i].name %>'}))"><i class="material-icons text-muted">delete_forever</i></a>
+                                                <a data-l10n-id="seeJournalEntries" title="See Journal Entries" href="/dashboard/journal/<%= data.users[i].private_journal %>?uid=<%= data.users[i]._id %>&type=private"><span class="journal-icon2"></span></a>
+                                                <a data-l10n-id="editUser" title="Edit User" href="/dashboard/users/edit/<%= data.users[i]._id %>"><i class="material-icons text-muted">edit</i></a>
+                                                <a data-l10n-id="deleteUser" title="Delete User" href="/dashboard/users/delete/<%= data.users[i]._id %>" onclick="return confirm(document.webL10n.get('DoYouWantDeleteUser',{user:'<%= data.users[i].name %>'}))"><i class="material-icons text-muted">delete_forever</i></a>
                                               </td>
                                           </tr>
                                         <% } %>


### PR DESCRIPTION
While creating/editing user/classroom, when the user clicks on add user. Page reloads and a success popup appears. I think the user should be redirected to the dashboard/users or dashboard/classroom views after the successful creation of a user/classroom. Current UX is a little confusing. The user can click on create user button multiple times.

Current behavior:
![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/24666770/54028183-359a1380-41ca-11e9-8238-3b2d50952414.gif)

Expected behavior:
![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/24666770/54028193-3f237b80-41ca-11e9-8eb5-f2fb5a3cf1b9.gif)

