### PR TITLE
[FIX] Creating classroom with single student

### DIFF
--- a/dashboard/controller/classrooms.js
+++ b/dashboard/controller/classrooms.js
@@ -38,7 +38,7 @@ exports.index = function(req, res) {
 		query['offset'] = req.query.offset;
 	}
 
-    // call
+	// call
 	request({
 		headers: common.getHeaders(req),
 		json: true,
@@ -73,6 +73,9 @@ exports.addClassroom = function(req, res) {
 		// validate
 		req.body.name = req.body.name.trim();
 		req.body.students = req.body.students || [];
+		if (typeof req.body.students == 'string') {
+			req.body.students = [req.body.students];
+		}
 		req.body.color = JSON.parse(req.body.color);
 		req.assert('name', common.l10n.get('UsernameInvalid')).matches(/^[a-z0-9 ]+$/i);
 		req.body.options = { sync: true, stats: true };
@@ -136,8 +139,8 @@ exports.editClassroom = function(req, res) {
 			req.body.name = req.body.name.trim();
 			req.body.students = req.body.students || [];
 			
-			if (isString(req.body.students)) {
-				req.body.students = [req.body.students]
+			if (typeof req.body.students == 'string') {
+				req.body.students = [req.body.students];
 			}
 
 			req.body.color = JSON.parse(req.body.color);
@@ -205,9 +208,6 @@ exports.editClassroom = function(req, res) {
 			msg: common.l10n.get('ThereIsError')
 		});
 		return res.redirect('/dashboard/classrooms');
-	}
-	function isString(arg) {
-		return typeof arg === 'string';
 	}
 };
 


### PR DESCRIPTION
When I add a classroom with a single student, a string is stored in the DB instead of an array.

Steps to reproduce the  error:
1. Login to the dashboard. Click on `Classrooms` tab.
2. Click on `ADD CLASSROOM` button and create a classroom with one student.
3. If you check the database, you'll find a string insted of an array in the classrooms collection. If you list the classrooms, count for that classroom will be incorrect and `view students` button will be disabled.

Current Behavior:
![screenshot from 2019-03-08 18-55-01](https://user-images.githubusercontent.com/24666770/54031566-1ce32b00-41d5-11e9-8f0c-b360d8ce303f.png)
(See the last classroom. Student count is incorrect and we view students button is disabled.)


Expected Behavior:
![screenshot from 2019-03-08 18-58-38](https://user-images.githubusercontent.com/24666770/54031578-2a98b080-41d5-11e9-8f55-39f56ec0b105.png)

P.S. Also removed a function defined inside a function. The scope of the function was incorrect and it was unnecessary.
