### PR TITLE
Fix the ordering of activities while sorting

### DIFF
--- a/dashboard/public/js/main.js
+++ b/dashboard/public/js/main.js
@@ -5,6 +5,7 @@ function initDragDrop() {
 	$("ol.simple_with_animation").sortable({
 		group: 'simple_with_animation',
 		pullPlaceholder: false,
+		placeholder: '<div class="placeholder"></div>',
 		// animation on drop
 		onDrop: function($item, container, _super) {
 			var $clonedItem = $('<li/>').css({


### PR DESCRIPTION
While sorting the activities, the numbering of the activities appears ambiguous on picking up the element.
On dragging an item, it appears as if there is a vacancy of two elements instead of one.

Current Behavior:
![Sugarizer Dashboard (6)](https://user-images.githubusercontent.com/24666770/54205066-980d4f80-44fb-11e9-9a16-eb098596976e.gif)

Expected Behavior:
![Sugarizer Dashboard (5)](https://user-images.githubusercontent.com/24666770/54205078-a0658a80-44fb-11e9-9ba3-04228ad0a16a.gif)

Solution: The wrong ordering is due to the hidden `<li>` placeholder element. I used `<div>` for the placeholder instead so it's not causing ambiguities in the ordering of the list.