### PR TITLE
Fix Statistics page showing all users as inactive

### DIFF
--- a/dashboard/controller/stats.js
+++ b/dashboard/controller/stats.js
@@ -182,14 +182,12 @@ function getHowUsersAreActive(req, res) {
 	// get data
 	getUsers(req, res, { role: 'student' }, function(body) {
 		total = body.total;
-		data.data.push(body.total);
 		data.labels.push(common.l10n.get('UserActive'));
 
 		getUsers(req, res, { role: 'student', stime: moment().subtract(1, 'months').valueOf() }, function(body) {
-			data.data.push(body.total);
+			data.data.unshift(body.total);
 			data.labels.push(common.l10n.get('UserNotActive'));
 
-			data.data[0] = total - data.data[1];
 			data.data[1] = total - data.data[0];
 
 			//return

--- a/dashboard/controller/stats.js
+++ b/dashboard/controller/stats.js
@@ -182,12 +182,12 @@ function getHowUsersAreActive(req, res) {
 	// get data
 	getUsers(req, res, { role: 'student' }, function(body) {
 		total = body.total;
+		data.data.push(body.total);
 		data.labels.push(common.l10n.get('UserActive'));
 
 		getUsers(req, res, { role: 'student', stime: moment().subtract(1, 'months').valueOf() }, function(body) {
 			data.data.unshift(body.total);
 			data.labels.push(common.l10n.get('UserNotActive'));
-
 			data.data[1] = total - data.data[0];
 
 			//return


### PR DESCRIPTION
Fixes #95 

- All users were active during last month:
![active 1](https://user-images.githubusercontent.com/20889958/54252284-daae4680-4552-11e9-9eef-3c259c81e339.gif)

- Three users were active and two users weren't:
![active 2](https://user-images.githubusercontent.com/20889958/54252291-dc780a00-4552-11e9-86b7-6cfc56628035.gif)
