### PR TITLE
Remember filled in new user data when there's a data validation error

### DIFF
--- a/dashboard/controller/users.js
+++ b/dashboard/controller/users.js
@@ -117,7 +117,21 @@ exports.addUser = function(req, res) {
 			});
 		} else {
 			req.flash('errors', errors);
-			return res.redirect('/dashboard/users/add');
+			return res.render('addEditUser', {
+				module: 'users',
+				user: {
+					name:req.body.name,
+					password: req.body.password,
+					color: req.body.color,
+					language:req.body.language,
+					role:req.body.role
+				},
+				xocolors: xocolors,
+				moment: moment,
+				emoji: emoji,
+				account: req.session.user,
+				server: ini.information
+			});
 		}
 
 	} else {


### PR DESCRIPTION
As seen in the below GIF, when the admin creates a new user, if there's a data validation error in the _Name_ or _Password_ field, **all the entered data is cleared** when the alerts pop up.

![new user data](https://user-images.githubusercontent.com/20889958/54256948-5a91dc00-4566-11e9-873e-10ffa1df2dcb.gif)

---

**Fix:** Remember all the filled in data (Name, Language, Role, Color, Password) after alerts pops up.

![new user data new](https://user-images.githubusercontent.com/20889958/54256953-5d8ccc80-4566-11e9-8b5a-afeaecae7eba.gif)
