### PR TITLE
Fixes breaking tests. Handling admin deletion 

### DIFF
--- a/api/controller/users.js
+++ b/api/controller/users.js
@@ -627,14 +627,6 @@ exports.removeUser = function(req, res) {
 			});
 			return;
 		}
-	} else{
-		if (req.user._id == req.params.uid) {
-			res.status(400).send({
-				'error': 'Please login with another admin account before deleting your account',
-				'code': 20
-			});
-			return;
-		}
 	}
 
 	//delete user from db

--- a/dashboard/controller/users.js
+++ b/dashboard/controller/users.js
@@ -213,6 +213,12 @@ exports.editUser = function(req, res) {
 exports.deleteUser = function(req, res) {
 
 	if (req.params.uid) {
+		if (req.params.uid == common.getHeaders(req)['x-key']) {
+			req.flash('errors', {
+				msg: common.l10n.get('ErrorCode20')
+			});
+			return res.redirect('/dashboard/users');
+		}
 		request({
 			headers: common.getHeaders(req),
 			json: true,


### PR DESCRIPTION
The tests were failing after PR #83 

Moved the logic to check that if the admin is deleting himself to `dashboard/controller`

Failing tests:
![Screenshot from 2019-03-13 17-03-13](https://user-images.githubusercontent.com/24666770/54275921-f72d9b80-45b1-11e9-84f7-bd4cfed8c17e.png)

After fix:
![Screenshot from 2019-03-13 17-03-30](https://user-images.githubusercontent.com/24666770/54275965-10cee300-45b2-11e9-89b7-39977c09963a.png)

The functionality introduced by #83 is also handled and is working as expected.