### PR TITLE
UX Improvement. List admins after create/update/delete admin

### DIFF
--- a/dashboard/controller/users.js
+++ b/dashboard/controller/users.js
@@ -102,12 +102,16 @@ exports.addUser = function(req, res) {
 				uri: common.getAPIUrl(req) + 'api/v1/users'
 			}, function(error, response, body) {
 				if (response.statusCode == 200) {
-
-					// send to users page
 					req.flash('success', {
 						msg: common.l10n.get('UserCreated')
 					});
-					return res.redirect('/dashboard/users/');
+					if (body.role == "admin") {
+						// send to admin page
+						return res.redirect('/dashboard/users/?role=admin');
+					} else {
+						// send to users page
+						return res.redirect('/dashboard/users/');
+					}
 				} else {
 					req.flash('errors', {
 						msg: common.l10n.get('ErrorCode'+body.code)
@@ -158,12 +162,16 @@ exports.editUser = function(req, res) {
 					uri: common.getAPIUrl(req) + 'api/v1/users/' + req.params.uid
 				}, function(error, response, body) {
 					if (response.statusCode == 200) {
-
-						// send back
 						req.flash('success', {
 							msg: common.l10n.get('UserUpdated')
 						});
-						return res.redirect('/dashboard/users/');
+						if (body.role == "admin") {
+							// send to admin page
+							return res.redirect('/dashboard/users/?role=admin');
+						} else {
+							// send to users page
+							return res.redirect('/dashboard/users/');
+						}
 					} else {
 						req.flash('errors', {
 							msg: common.l10n.get('ErrorCode'+body.code)
@@ -213,11 +221,12 @@ exports.editUser = function(req, res) {
 exports.deleteUser = function(req, res) {
 
 	if (req.params.uid) {
+		var role = req.query.role || 'student';
 		if (req.params.uid == common.getHeaders(req)['x-key']) {
 			req.flash('errors', {
 				msg: common.l10n.get('ErrorCode20')
 			});
-			return res.redirect('/dashboard/users');
+			return res.redirect('/dashboard/users/?role='+role);
 		}
 		request({
 			headers: common.getHeaders(req),
@@ -236,7 +245,7 @@ exports.deleteUser = function(req, res) {
 					msg: common.l10n.get('ErrorCode'+body.code)
 				});
 			}
-			return res.redirect('/dashboard/users');
+			return res.redirect('/dashboard/users?role='+role);
 		});
 	} else {
 		req.flash('errors', {

--- a/dashboard/views/users.ejs
+++ b/dashboard/views/users.ejs
@@ -115,7 +115,7 @@
                                               <td>
                                                 <a data-l10n-id="seeJournalEntries" title="See Journal Entries" href="/dashboard/journal/<%= data.users[i].private_journal %>?uid=<%= data.users[i]._id %>&type=private"><span class="journal-icon2"></span></a>
                                                 <a data-l10n-id="editUser" title="Edit User" href="/dashboard/users/edit/<%= data.users[i]._id %>"><i class="material-icons text-muted">edit</i></a>
-                                                <a data-l10n-id="deleteUser" title="Delete User" href="/dashboard/users/delete/<%= data.users[i]._id %>" onclick="return confirm(document.webL10n.get('DoYouWantDeleteUser',{user:'<%= data.users[i].name %>'}))"><i class="material-icons text-muted">delete_forever</i></a>
+                                                <a data-l10n-id="deleteUser" title="Delete User" href="/dashboard/users/delete/<%= data.users[i]._id %>?role=<%= data.users[i].role %>" onclick="return confirm(document.webL10n.get('DoYouWantDeleteUser',{user:'<%= data.users[i].name %>'}))"><i class="material-icons text-muted">delete_forever</i></a>
                                               </td>
                                           </tr>
                                         <% } %>


### PR DESCRIPTION
I was facing this issue while testing PR #101.

After creating/editing/deleting an admin, the app returns me to users view listing students instead of admins. It's really frustrating to delete/edit multiple admins and It's difficult to keep track of your last action.

Current behavior:
![Sugarizer Dashboard (8)](https://user-images.githubusercontent.com/24666770/54279605-812e3200-45bb-11e9-97b4-879142b8bbbd.gif)

Expected behavior:
![Sugarizer Dashboard (7)](https://user-images.githubusercontent.com/24666770/54279628-8c815d80-45bb-11e9-9261-d472383726fc.gif)
(When user creates/updates/deletes admin, he gets the list of admins)