### PR TITLE
Search for stroke and fill fixed

### DIFF
--- a/dashboard/public/js/main.js
+++ b/dashboard/public/js/main.js
@@ -177,6 +177,25 @@ function formatColorField(state) {
 	return $state;
 }
 
+function matchColorField(params, data) {
+	if ($.trim(params.term) === '') {
+		return data;
+	}
+	params.term = params.term.toUpperCase();
+
+	if (typeof data.text === 'undefined') {
+		return null;
+	}
+
+	if (data.id.indexOf(params.term) > -1) {
+		var modifiedData = $.extend({}, data, true);
+		modifiedData.text += ' (matched)';
+		return modifiedData;
+	}
+
+	return null;
+}
+
 $(document).ready(function() {
 	if ($("#users-select2").length > 0) {
 		$("#users-select2").select2({
@@ -197,7 +216,8 @@ $(document).ready(function() {
 	if ($("#color-select2").length > 0) {
 		$("#color-select2").select2({
 			templateResult: formatColorField,
-			templateSelection: formatColorField
+			templateSelection: formatColorField,
+			matcher: matchColorField
 		})
 	}
 


### PR DESCRIPTION
The search for stroke and fill color was not working while creating user/classroom.

Current Behavior:
![Screenshot from 2019-03-14 22-32-18](https://user-images.githubusercontent.com/24666770/54376876-fe37d500-46a9-11e9-9acc-eaf991dd6991.png)

Expected Behavior:
![Screenshot from 2019-03-14 22-34-06](https://user-images.githubusercontent.com/24666770/54376892-0859d380-46aa-11e9-9ceb-cf172365a4fa.png)
