### PR TITLE
Updated deprecated mongodb functions

### DIFF
--- a/api/controller/classrooms.js
+++ b/api/controller/classrooms.js
@@ -124,7 +124,7 @@ exports.removeClassroom = function(req, res) {
   }
 
   db.collection(classroomsCollection, function(err, collection) {
-    collection.remove(
+    collection.deleteOne(
       {
         _id: new mongo.ObjectID(req.params.classid)
       },

--- a/api/controller/journal.js
+++ b/api/controller/journal.js
@@ -696,7 +696,7 @@ exports.removeInJournal = function(req, res) {
 	//whether or partial is deleted!
 	if (type == 'full') {
 		db.collection(journalCollection, function(err, collection) {
-			collection.remove({
+			collection.deleteOne({
 				'_id': new mongo.ObjectID(jid)
 			}, function(err, result) {
 				if (err) {

--- a/api/controller/stats.js
+++ b/api/controller/stats.js
@@ -148,7 +148,7 @@ exports.deleteStats = function(req, res) {
 	}
 
 	db.collection(statsCollection, function(err, collection) {
-		collection.remove({
+		collection.deleteOne({
 			'user_id': req.query.uid
 		}, function(err, result) {
 			if (err) {

--- a/api/controller/users.js
+++ b/api/controller/users.js
@@ -635,7 +635,7 @@ exports.removeUser = function(req, res) {
 	//delete user from db
 	var uid = req.params.uid;
 	db.collection(usersCollection, function(err, collection) {
-		collection.remove({
+		collection.deleteOne({
 			'_id': new mongo.ObjectID(uid)
 		}, function(err, result) {
 			if (err) {
@@ -647,12 +647,11 @@ exports.removeUser = function(req, res) {
 				if (result && result.result && result.result.n == 1) {
 					// Remove user form classroom
 					db.collection(classroomsCollection, function(err, collection) {
-						collection.update({},
+						collection.updateMany({},
 							{
 								$pull: { students: uid}
-							},
-							{
-								multi: true
+							}, {
+								safe: true
 							},
 							function(err, result) {
 								if (err) {

--- a/api/test/activities.js
+++ b/api/test/activities.js
@@ -5,16 +5,16 @@ process.env.NODE_ENV = 'test';
 var server = require('../../sugarizer.js');
 var chai = require('chai');
 var chaiHttp = require('chai-http');
-var should = chai.should();
 var timestamp = +new Date();
 
 //fake user for testing auth
 var fakeUser = {
-	"user": '{"name":"TarunFake' + (timestamp.toString()) + '","password":"pokemon","role":"admin"}'
+	"user": '{"name":"TarunFake' + (timestamp.toString()) + '","password":"pokemon","language":"en","role":"admin"}'
 };
 
 //init server
 chai.use(chaiHttp);
+chai.should();
 
 describe('Activities', function() {
 
@@ -50,7 +50,7 @@ describe('Activities', function() {
 				.set('x-key', fakeUser.user._id)
 				.end((err, res) => {
 					res.should.have.status(200);
-					res.body.should.be.a('array');
+					res.body.should.be.an('array');
 					res.body.length.should.be.gt(10);
 					done();
 				});
@@ -65,7 +65,7 @@ describe('Activities', function() {
 					res.should.have.status(200);
 					for (var i = 0; i < res.body.length; i++) {
 
-						res.body[i].should.be.a('object');
+						res.body[i].should.be.an('object');
 						res.body[i].should.have.property('id').not.eql(undefined);
 						res.body[i].should.have.property('name').not.eql(undefined);
 						res.body[i].should.have.property('version').not.eql(undefined);
@@ -88,7 +88,7 @@ describe('Activities', function() {
 				.set('x-key', fakeUser.user._id)
 				.end((err, res) => {
 					res.should.have.status(200);
-					res.body.should.be.a('array');
+					res.body.should.be.an('array');
 					res.body.length.should.be.eql(3);
 					done();
 				});

--- a/api/test/classrooms.js
+++ b/api/test/classrooms.js
@@ -5,19 +5,19 @@ process.env.NODE_ENV = 'test';
 var server = require('../../sugarizer.js');
 var chai = require('chai');
 var chaiHttp = require('chai-http');
-var should = chai.should();
 var timestamp = +new Date();
 
 //fake user for testing auth
 var fake = {
 	'student1': '{"name":"Sugarizer_1' + (timestamp.toString()) + '","color":{"stroke":"#FF0000","fill":"#0000FF"},"role":"student","password":"pass","language":"fr"}',
 	'student2': '{"name":"Sugarizer_2' + (timestamp.toString()) + '","color":{"stroke":"#FF0000","fill":"#0000FF"},"role":"student","password":"word","language":"en"}',
-	'admin': '{"name":"TarunFake_' + (timestamp.toString()) + '","password":"pokemon","role":"admin"}',
+	'admin': '{"name":"TarunFake_' + (timestamp.toString()) + '","password":"pokemon","language":"en","role":"admin"}',
 	'classroom': '{"name":"group_a_' + (timestamp.toString()) + '","color":{"stroke":"#FF0000","fill":"#0000FF"},"students":[]}'
-}
+};
 
 //init server
 chai.use(chaiHttp);
+chai.should();
 
 describe('Classrooms', function() {
 
@@ -88,7 +88,7 @@ describe('Classrooms', function() {
 				.end((err, res) => {
 					res.should.have.status(200);
 					fake.classroom = res.body;
-					res.body.should.be.a('object');
+					res.body.should.be.an('object');
 					res.body.should.have.property('_id').not.eql(undefined);
 					res.body.should.have.property('name').eql("group_a_" + (timestamp.toString()));
 					res.body.should.have.property('color').not.eql(undefined);
@@ -188,7 +188,7 @@ describe('Classrooms', function() {
 				.set('x-key', fake.admin.user._id)
 				.end((err, res) => {
 					res.should.have.status(200);
-					res.body.classrooms.should.be.a('array');
+					res.body.classrooms.should.be.an('array');
 					res.body.classrooms.length.should.be.above(0);
 					done();
 				});
@@ -203,7 +203,7 @@ describe('Classrooms', function() {
 				.end((err, res) => {
 					res.should.have.status(200);
 					for (var i = 0; i < res.body.classrooms.length; i++) {
-						res.body.classrooms[i].should.be.a('object');
+						res.body.classrooms[i].should.be.an('object');
 						res.body.classrooms[i].should.have.property('_id').not.eql(undefined);
 						res.body.classrooms[i].should.have.property('name').not.eql(undefined);
 						res.body.classrooms[i].should.have.property('color').not.eql(undefined);
@@ -275,7 +275,7 @@ describe('Classrooms', function() {
 				})
 				.end((err, res) => {
 					res.should.have.status(200);
-					res.body.should.be.a('object');
+					res.body.should.be.an('object');
 					res.body.should.have.property('_id').eql(fake.classroom._id);
 					res.body.should.have.property('name').eql("group_new_a_" + (timestamp.toString()));
 					done();

--- a/api/test/journal.js
+++ b/api/test/journal.js
@@ -5,17 +5,17 @@ process.env.NODE_ENV = 'test';
 var server = require('../../sugarizer.js');
 var chai = require('chai');
 var chaiHttp = require('chai-http');
-var should = chai.should();
 var timestamp = +new Date();
 
 //fake user for testing auth
 var fakeUser = {
 	'student': '{"name":"Sugarizer' + (timestamp.toString()) + '","color":{"stroke":"#FF0000","fill":"#0000FF"},"role":"student","password":"pass","language":"fr"}',
-	'admin': '{"name":"TarunFake' + (timestamp.toString()) + '","password":"pokemon","role":"admin"}'
-}
+	'admin': '{"name":"TarunFake' + (timestamp.toString()) + '","password":"pokemon","language":"en","role":"admin"}'
+};
 
 //init server
 chai.use(chaiHttp);
+chai.should();
 
 describe('Journal', function() {
 

--- a/api/test/stats.js
+++ b/api/test/stats.js
@@ -5,16 +5,16 @@ process.env.NODE_ENV = 'test';
 var server = require('../../sugarizer.js');
 var chai = require('chai');
 var chaiHttp = require('chai-http');
-var should = chai.should();
 var timestamp = +new Date();
 
 //fake user for testing auth
 var fakeUser = {
 	'student': '{"name":"Sugarizer' + (timestamp.toString()) + '","color":{"stroke":"#FF0000","fill":"#0000FF"},"role":"student","password":"pass","language":"fr"}'
-}
+};
 
 //init server
 chai.use(chaiHttp);
+chai.should();
 
 describe('Stats', function() {
 

--- a/api/test/users.js
+++ b/api/test/users.js
@@ -5,17 +5,17 @@ process.env.NODE_ENV = 'test';
 var server = require('../../sugarizer.js');
 var chai = require('chai');
 var chaiHttp = require('chai-http');
-var should = chai.should();
 var timestamp = +new Date();
 
 //fake user for testing auth
 var fakeUser = {
 	'student': '{"name":"Sugarizer_' + (timestamp.toString()) + '","color":{"stroke":"#FF0000","fill":"#0000FF"},"role":"student","password":"pass","language":"fr"}',
-	'admin': '{"name":"TarunFake_' + (timestamp.toString()) + '","password":"pokemon","role":"admin"}'
-}
+	'admin': '{"name":"TarunFake_' + (timestamp.toString()) + '","password":"pokemon","language":"en","role":"admin"}'
+};
 
 //init server
 chai.use(chaiHttp);
+chai.should();
 
 describe('Users', function() {
 
@@ -59,7 +59,7 @@ describe('Users', function() {
 				.end((err, res) => {
 					res.should.have.status(200);
 					fakeUser.student = res.body;
-					res.body.should.be.a('object');
+					res.body.should.be.an('object');
 					res.body.should.have.property('_id').not.eql(undefined);
 					res.body.should.have.property('name').eql("Sugarizer_" + (timestamp.toString()));
 					res.body.should.have.property('role').eql('student');
@@ -124,7 +124,7 @@ describe('Users', function() {
 				.set('x-key', fakeUser.admin.user._id)
 				.end((err, res) => {
 					res.should.have.status(200);
-					res.body.should.be.a('object');
+					res.body.should.be.an('object');
 					res.body.should.have.property('_id').eql(fakeUser.student._id);
 					res.body.should.have.property('name').eql("Sugarizer_" + (timestamp.toString()));
 					res.body.should.have.property('role').eql('student');
@@ -150,7 +150,7 @@ describe('Users', function() {
 				})
 				.end((err, res) => {
 					res.should.have.status(200);
-					res.body.users.should.be.a('array');
+					res.body.users.should.be.an('array');
 					res.body.users.length.should.be.above(0);
 					done();
 				});
@@ -169,7 +169,7 @@ describe('Users', function() {
 					res.should.have.status(200);
 					for (var i = 0; i < res.body.users.length; i++) {
 
-						res.body.users[i].should.be.a('object');
+						res.body.users[i].should.be.an('object');
 						res.body.users[i].should.have.property('_id').not.eql(undefined);
 						res.body.users[i].should.have.property('name').not.eql(undefined);
 						res.body.users[i].should.have.property('role').eql('admin');
@@ -192,7 +192,7 @@ describe('Users', function() {
 					res.should.have.status(200);
 					for (var i = 0; i < res.body.users.length; i++) {
 
-						res.body.users[i].should.be.a('object');
+						res.body.users[i].should.be.an('object');
 						res.body.users[i].should.have.property('_id').not.eql(undefined);
 						res.body.users[i].should.have.property('name').not.eql(undefined);
 						res.body.users[i].should.have.property('role').eql('student');
@@ -307,7 +307,7 @@ describe('Users', function() {
 						.set('x-key', fakeUser.admin.user._id)
 						.end((err, res) => {
 							res.should.have.status(200);
-							res.body.should.be.a('object');
+							res.body.should.be.an('object');
 							res.body.should.have.property('_id').eql(fakeUser.student._id);
 							res.body.should.have.property('name').eql("Sugarizer_" + (timestamp.toString()));
 							res.body.should.have.property('language').eql("en");


### PR DESCRIPTION
- Some of the MongoDB functions were deprecated. They have been updated with a suitable alternative.
![Screenshot from 2019-03-15 14-13-51](https://user-images.githubusercontent.com/24666770/54419134-b6a65d00-472c-11e9-83a0-36652c8baf88.png)

- In the tests, while creating fake admin, the language parameter is passed to admin which was previously missing.
- Following [chaijs docs](https://www.chaijs.com/api/bdd/) I updated `be.a('array')` and `be.a('object')` with `be.an('array')` and `be.an('object')` respectively.

