### PR TITLE
Add username in the "Recent Entries" table

### DIFF
--- a/dashboard/controller/graph.js
+++ b/dashboard/controller/graph.js
@@ -251,6 +251,7 @@ function getRecentActivities(req, res) {
 										<td><div class="color" id="' + allEntries[i].objectId + i.toString() + '"><div class="xo-icon"></div></div></td>\
 										<script>new icon().load("' +  (hashList[allEntries[i].metadata.activity] || '/public/img/application-x-generic.svg') + '", ' + JSON.stringify(allEntries[i].metadata.buddy_color) + ', "' + allEntries[i].objectId + i.toString() + '")</script>\
 										<td title="' + allEntries[i].metadata.title + '">' + allEntries[i].metadata.title + '</td>\
+										<td title="' + allEntries[i].metadata.buddy_name + '">' + allEntries[i].metadata.buddy_name + '</td>\
 										<td class="text-muted">' + moment(allEntries[i].metadata.timestamp).calendar() + '</td>\
 								</tr>'
 			}

--- a/dashboard/views/dashboard.ejs
+++ b/dashboard/views/dashboard.ejs
@@ -129,7 +129,8 @@
                         <tr>
                             <th>#</th>
 														<th data-l10n-id="icon">Icon</th>
-                            <th data-l10n-id="name">Name</th>
+														<th data-l10n-id="activity">Activity</th>
+														<th data-l10n-id="username">Username</th>
 														<th data-l10n-id="timestamp">Timestamp</th>
                         </tr>
                     </thead>


### PR DESCRIPTION
**Current state:**
The admin doesn't know to whom any of these activities belong. 
Currently the admin can launch a specific instance of an activity by clicking on it in the table, but since he doesn't know the owner of any of these activities, he/she can't tell who made this progress in the activity which makes the point of launching it from the table useless.

![old](https://user-images.githubusercontent.com/20889958/54500264-9ab8dc00-4923-11e9-97ff-cdc1a2f1fa6b.PNG)

---

**After PR:**

![new](https://user-images.githubusercontent.com/20889958/54500261-97bdeb80-4923-11e9-8427-3b22852314c7.PNG)