### PR TITLE
Fix console error on bar chart onClick

### DIFF
--- a/dashboard/public/js/main.js
+++ b/dashboard/public/js/main.js
@@ -299,7 +299,7 @@ function createGraph(type, element, route) {
 				var html = '<div class="text-center">\
 											<i class="material-icons dp96 text-muted">info_outline</i>\
 											<p data-l10n-id="noGraphDataText">' + document.webL10n.get('noGraphDataText') + '</p>\
-										</div>'
+										</div>';
 				$("#" + response.element).replaceWith(html);
 			} else {
 				var ctx = document.getElementById(response.element).getContext('2d');
@@ -308,19 +308,28 @@ function createGraph(type, element, route) {
 					data: response.data,
 					options: (response.options ? response.options : {})
 				});
-				myChart.options.onClick = function(e){
-					var activePoints = myChart.getElementsAtEvent(e);
-					// Avoid console erros when clicking on any white space in the chart
-					var index = activePoints.length ? activePoints[0]._index : -1;
-					if (index > -1 && response.graph === 'bar'){
-						window.location.href = `/dashboard/journal/${response.journalIDs[index]}?uid=${response.userIDs[index]}&type=private`;
-					}else if(index > -1 && response.graph === 'doughnut'){
-						window.location.href = `javascript:launch_activity('/dashboard/activities/launch?aid=${response.activityIDs[index]}')`;
-					}
+				if (type == 'top-contributor') {
+					myChart.options.onClick = function(e) {
+						var activePoints = myChart.getElementsAtEvent(e);
+						// Avoid console erros when clicking on any white space in the chart
+						var index = activePoints.length ? activePoints[0]._index : -1;
+						if (index > -1) {
+							window.location.href = "/dashboard/journal/" + response.journalIDs[index] + "?uid=" + response.userIDs[index] + "&type=private";
+						}
+					};
+				} else if (type == 'top-activities') {
+					myChart.options.onClick = function(e) {
+						var activePoints = myChart.getElementsAtEvent(e);
+						// Avoid console erros when clicking on any white space in the chart
+						var index = activePoints.length ? activePoints[0]._index : -1;
+						if (index > -1) {
+							window.location.href = "javascript:launch_activity('/dashboard/activities/launch?aid="+response.activityIDs[index]+"')";
+						}
+					};
 				}
 			}
 		});
-	})
+	});
 }
 
 function createTable(type, element, route) {


### PR DESCRIPTION
Steps to reproduce the error:
1. Open dashboard. Navigate to statistics page.
2. Keep the developer console open and click on "How often users are changing their profile settings?" chart.
You'll get an error like this:
![Screenshot from 2019-03-19 13-20-18](https://user-images.githubusercontent.com/24666770/54590214-8ec93900-4a4d-11e9-837d-fae8983396d5.png)

Cause of error: In PR #85 an event listener was added to all the charts. It should be added to only a couple of charts. The error was popping because of the event listener being attached to the wrong chart and the function breaking down because of undefined variables.

In this PR:
- Instead of attaching the event listener to all the charts. It's attached to only selected charts thus eliminating the error and the improving efficiency.
- ES6 template literals were removed due to lack of support in the older browsers version.