### PR TITLE
Fix launching activity with null text

### DIFF
--- a/dashboard/public/js/main.js
+++ b/dashboard/public/js/main.js
@@ -63,7 +63,7 @@ function launch_activity(callurl) {
 			lsBackup[index] = localStorage.getItem(index);
 			var encodedValue = response.lsObj[index];
 			var rawValue = JSON.parse(encodedValue);
-			if (rawValue.server) {
+			if (rawValue && rawValue.server) {
 				rawValue.server.url = window.location.protocol+"//"+window.location.hostname+":"+rawValue.server.web;
 				encodedValue = JSON.stringify(rawValue);
 			}


### PR DESCRIPTION
Fixes #130 

Currently, when we try to launch an activity with null journal entry text from the dashboard. The activity fails to launch and we get an error in the console:
![Screenshot from 2019-03-19 12-33-57](https://user-images.githubusercontent.com/24666770/54591103-883bc100-4a4f-11e9-9632-c4ac96f3135b.png)

It was fixed by adding a simple null check in the `launch_activity` function.