### PR TITLE
Re-init l10n in stats controller

### DIFF
--- a/dashboard/controller/stats.js
+++ b/dashboard/controller/stats.js
@@ -13,8 +13,9 @@ exports.init = function(settings) {
 // main landing page
 exports.index = function(req, res) {
 
-	// reinit momemt with locale
+	// reinit l10n and momemt with locale
 	if (req.query && req.query.lang) {
+		common.l10n.setLanguage(req.query.lang);
 		moment.locale(req.query.lang);
 	}
 


### PR DESCRIPTION
The l10n instance was not initiated on the stats controller.
If a user switched language and moved to stats page, the language of the graphs was not changed.

Current Behavior:
![Sugarizer Dashboard (11)](https://user-images.githubusercontent.com/24666770/54671762-90adfd80-4b1c-11e9-84de-72eeadb80949.gif)

Expected Behavior:
![Sugarizer Dashboard (12)](https://user-images.githubusercontent.com/24666770/54671773-94da1b00-4b1c-11e9-875f-0551d13a4ced.gif)
