### PR TITLE
Fixed placeholder translation in addEditClassroom

### DIFF
--- a/dashboard/views/addEditClassroom.ejs
+++ b/dashboard/views/addEditClassroom.ejs
@@ -37,8 +37,8 @@
                                     <script type="text/javascript">
                                         // run multiSelect
                                         $('#searchable-select-students').multiSelect({
-                                            selectableHeader: "<input type='text' class='form-control' data-l10n-id='john.placeholder' autocomplete='off' placeholder='search students'>",
-                                            selectionHeader: "<input type='text' class='form-control' data-l10n-id='john.placeholder' autocomplete='off' placeholder='search students'>",
+                                            selectableHeader: "<input type='text' class='form-control' data-l10n-id='john' autocomplete='off' placeholder='search students'>",
+                                            selectionHeader: "<input type='text' class='form-control' data-l10n-id='john' autocomplete='off' placeholder='search students'>",
                                             afterInit: function(ms){
                                                 var that = this,
                                                     $selectableSearch = that.$selectableUl.prev(),


### PR DESCRIPTION
The placeholder in the addEditClassroom view for `Search Students` field was not being translated due to a typo and we were also getting warnings in the console.
![Screenshot from 2019-03-20 14-53-59](https://user-images.githubusercontent.com/24666770/54673318-036ca800-4b20-11e9-92d7-383b293ccd69.png)

Fixed:
![Screenshot from 2019-03-20 14-48-00](https://user-images.githubusercontent.com/24666770/54673376-24cd9400-4b20-11e9-945f-d13deb04079e.png)
