### PR TITLE
Show view journal button only for students in users view

### DIFF
--- a/dashboard/views/users.ejs
+++ b/dashboard/views/users.ejs
@@ -113,7 +113,9 @@
                                               <td><%= data.users[i].role %></td>
                                               <td><%= moment(data.users[i].timestamp).calendar() %></td>
                                               <td>
+                                                <% if(data.users[i].role == 'student') {%>
                                                 <a data-l10n-id="seeJournalEntries" title="See Journal Entries" href="/dashboard/journal/<%= data.users[i].private_journal %>?uid=<%= data.users[i]._id %>&type=private"><span class="journal-icon2"></span></a>
+                                                <% } %>
                                                 <a data-l10n-id="editUser" title="Edit User" href="/dashboard/users/edit/<%= data.users[i]._id %>"><i class="material-icons text-muted">edit</i></a>
                                                 <a data-l10n-id="deleteUser" title="Delete User" href="/dashboard/users/delete/<%= data.users[i]._id %>?role=<%= data.users[i].role %>&name=<%= data.users[i].name %>" onclick="return confirm(document.webL10n.get('DoYouWantDeleteUser',{user:'<%= data.users[i].name %>'}))"><i class="material-icons text-muted">delete_forever</i></a>
                                               </td>


### PR DESCRIPTION
In general case, there seems no point of showing view journal button for admin and teachers on the users view. It should be displayed only for the student accounts.

Student:
![Screenshot from 2019-03-23 20-19-12](https://user-images.githubusercontent.com/24666770/54867685-0928ee80-4da9-11e9-8fb2-6a73ec78a4a8.png)

Admin/Teacher:
![Screenshot from 2019-03-23 20-19-04](https://user-images.githubusercontent.com/24666770/54867684-075f2b00-4da9-11e9-880c-f7fd2951383a.png)