### PR TITLE
Fix classroom for similar students

### DIFF
--- a/dashboard/controller/users.js
+++ b/dashboard/controller/users.js
@@ -43,6 +43,11 @@ exports.index = function(req, res) {
 		query['classid'] = req.query.classid;
 	}
 
+	var classroom_id;
+	if (req.query.classroom_id) {
+		classroom_id = req.query.classroom_id;
+	}
+
 	// call
 	request({
 		headers: common.getHeaders(req),
@@ -62,6 +67,7 @@ exports.index = function(req, res) {
 					moment: moment,
 					query: query,
 					classrooms: classrooms,
+					classroom_id: classroom_id,
 					data: body,
 					account: req.session.user,
 					server: ini.information

--- a/dashboard/views/users.ejs
+++ b/dashboard/views/users.ejs
@@ -25,17 +25,27 @@
 							  <script>$('#user-form [name="role"]').select2().on("change", () => show_class_fields())</script>
                           </div>
                         </div>
+                        <input name="classroom_id" type="text" style="display:none" %>" value="<% if(classroom_id) { %><%= classroom_id %><% } %>" />
                         <div class="col-md-2">
                           <div class="form-group form-black label-floating is-empty classroom_input">
                                 <select class="form-control" name="classid">
                                     <option value="" selected="selected" >None</option>
                                     <% for(var i=0; i < classrooms.length; i++) { %>
                                         <% if(Array.isArray(classrooms[i].students) && classrooms[i].students && classrooms[i].students.length > 0) { %>
-                                            <option value="<%- classrooms[i].students.join(',') %>" <% if(query.classid== classrooms[i].students.join(',')){ %>selected="selected"<% } %> ><%= classrooms[i].name %></option>
+                                            <option id="<%- classrooms[i]._id %>" value="<%- classrooms[i].students.join(',') %>" <% if(classroom_id == classrooms[i]._id) { %>selected="selected"<% } %> ><%= classrooms[i].name %></option>
                                         <% } %>
                                     <% } %>
                                 </select>
-                              <script> $('#user-form [name="classid"]').select2(); </script>
+                                <script>
+                                    $('#user-form [name="classid"]').select2().on("select2:select", function(e) {
+                                        var inputField = $('#user-form [name="classroom_id"]');
+                                        var value = "";
+                                        if (inputField && e && e.params && e.params.data && e.params.data.element && e.params.data.element.id) {
+                                            value = e.params.data.element.id;
+                                        }
+                                        inputField.val(value);
+                                    });
+                                </script>
                           </div>
                         </div>
 						<script>


### PR DESCRIPTION
While using filters in the `Users View`. If Class A and Class B have the same students. If we use the filter for Class B, then it displays the name of Class B in the select field.

![Sugarizer Dashboard (14)](https://user-images.githubusercontent.com/24666770/54878396-35e51080-4e52-11e9-9ef5-c2ffe4ce53a1.gif)


Fixed:
![Sugarizer Dashboard (15)](https://user-images.githubusercontent.com/24666770/54878437-efdc7c80-4e52-11e9-98d2-a0d223cba363.gif)


