### PR TITLE
Re-initiated locale on non-index views

### DIFF
--- a/dashboard/controller/classrooms.js
+++ b/dashboard/controller/classrooms.js
@@ -16,11 +16,8 @@ exports.init = function(settings) {
 // main landing page
 exports.index = function(req, res) {
 
-	// reinit l10n and moment with locale
-	if (req.query && req.query.lang) {
-		common.l10n.setLanguage(req.query.lang);
-		moment.locale(req.query.lang);
-	}
+	// reinit l10n and momemt with locale
+	common.reinitLocale(req);
 
 	//query
 	var query = {
@@ -67,6 +64,9 @@ exports.index = function(req, res) {
 };
 
 exports.addClassroom = function(req, res) {
+
+	// reinit l10n and momemt with locale
+	common.reinitLocale(req);
 
 	if (req.method == 'POST') {
 
@@ -131,6 +131,9 @@ exports.addClassroom = function(req, res) {
 };
 
 exports.editClassroom = function(req, res) {
+
+	// reinit l10n and momemt with locale
+	common.reinitLocale(req);
 
 	if (req.params.classid) {
 		if (req.method == 'POST') {

--- a/dashboard/controller/dashboard.js
+++ b/dashboard/controller/dashboard.js
@@ -13,11 +13,8 @@ exports.init = function(settings) {
 // main landing page
 exports.index = function(req, res) {
 
-	// reinit l10n and moment with locale
-	if (req.query && req.query.lang) {
-		common.l10n.setLanguage(req.query.lang);
-		moment.locale(req.query.lang);
-	}
+	// reinit l10n and momemt with locale
+	common.reinitLocale(req);
 
 	var data = {};
 

--- a/dashboard/controller/journal.js
+++ b/dashboard/controller/journal.js
@@ -15,11 +15,8 @@ exports.init = function(settings) {
 // main landing page
 exports.index = function(req, res) {
 
-	// reinit l10n and moment with locale
-	if (req.query && req.query.lang) {
-		common.l10n.setLanguage(req.query.lang);
-		moment.locale(req.query.lang);
-	}
+	// reinit l10n and momemt with locale
+	common.reinitLocale(req);
 
 	getUsers(req, res, function(users) {
 		res.render('journal', {
@@ -67,6 +64,9 @@ exports.deleteEntry = function(req, res) {
 };
 
 exports.getEntries = function(req, res) {
+
+	// reinit l10n and momemt with locale
+	common.reinitLocale(req);
 
 	//get users
 	getUsers(req, res, function(users) {

--- a/dashboard/controller/stats.js
+++ b/dashboard/controller/stats.js
@@ -14,10 +14,7 @@ exports.init = function(settings) {
 exports.index = function(req, res) {
 
 	// reinit l10n and momemt with locale
-	if (req.query && req.query.lang) {
-		common.l10n.setLanguage(req.query.lang);
-		moment.locale(req.query.lang);
-	}
+	common.reinitLocale(req);
 
 	// send to login page
 	res.render('stats', {

--- a/dashboard/controller/users.js
+++ b/dashboard/controller/users.js
@@ -16,10 +16,7 @@ exports.init = function(settings) {
 exports.index = function(req, res) {
 
 	// reinit l10n and moment with locale
-	if (req.query && req.query.lang) {
-		common.l10n.setLanguage(req.query.lang);
-		moment.locale(req.query.lang);
-	}
+	common.reinitLocale(req);
 
 	//query
 	var query = {
@@ -76,6 +73,9 @@ exports.index = function(req, res) {
 };
 
 exports.addUser = function(req, res) {
+
+	// reinit l10n and momemt with locale
+	common.reinitLocale(req);
 
 	if (req.method == 'POST') {
 
@@ -152,6 +152,9 @@ exports.addUser = function(req, res) {
 };
 
 exports.editUser = function(req, res) {
+
+	// reinit l10n and momemt with locale
+	common.reinitLocale(req);
 
 	if (req.params.uid) {
 		if (req.method == 'POST') {

--- a/dashboard/helper/common.js
+++ b/dashboard/helper/common.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var os = require('os');
 var ini = null;
 var language = '*';
+var moment = require('moment');
 
 exports.init = function(settings) {
 	ini = settings;
@@ -32,6 +33,14 @@ exports.l10n = {
 		return translate;
 	}
 }
+
+exports.reinitLocale = function(req) {
+	// reinit l10n and moment with locale
+	if (req.query && req.query.lang) {
+		exports.l10n.setLanguage(req.query.lang);
+		moment.locale(req.query.lang);
+	}
+};
 
 exports.loadCredentials = function(settings) {
 	if (!settings.security.certificate_file || !settings.security.key_file) {


### PR DESCRIPTION
Currently, the locale is re-initiated only on view's index page.
- This causes issues with switching locale on non-index views like:
![Sugarizer Dashboard (19)](https://user-images.githubusercontent.com/24666770/54915857-20d5b380-4f1e-11e9-8e5b-90a58d76b08b.gif)
![शुगरइज़र डैशबोर्ड](https://user-images.githubusercontent.com/24666770/54915859-20d5b380-4f1e-11e9-8118-05ade85ed9cb.gif)

- This causes an issue with the translation of notifications
![Sugarizer Dashboard (20)](https://user-images.githubusercontent.com/24666770/54915854-203d1d00-4f1e-11e9-9d80-45615c755ebc.gif)


This PR contains:
- Translation fix on non-index views:
![Sugarizer Dashboard (16)](https://user-images.githubusercontent.com/24666770/54915855-203d1d00-4f1e-11e9-920e-06f43f82e36c.gif)
![Sugarizer Dashboard (17)](https://user-images.githubusercontent.com/24666770/54915856-203d1d00-4f1e-11e9-84f3-1b505c5a53e9.gif)

- Translation fix for notifications:
![Sugarizer Dashboard (18)](https://user-images.githubusercontent.com/24666770/54915853-1fa48680-4f1e-11e9-99d1-57642de731c2.gif)



 