### PR TITLE
UX improvement. Fixed links and cursor

### DIFF
--- a/dashboard/public/css/main.css
+++ b/dashboard/public/css/main.css
@@ -196,7 +196,6 @@
 
 .color {
   margin: 0 0 5px 0;
-  cursor: pointer;
 }
 
 .color .xo-icon {

--- a/dashboard/views/activities.ejs
+++ b/dashboard/views/activities.ejs
@@ -37,7 +37,7 @@
 								<li>
 									<div class="card">
 										<div class="card-content">
-										<div class="col-lg-1 col-md-1 col-sm-1"><img class ="draggable" src="../public/img/font-awesome-ellipsis-v.png" alt="drag" style="width:40px;height:40px;"></div>
+										<div class="col-lg-1 col-md-1 col-sm-1"><img class ="draggable pointer" src="../public/img/font-awesome-ellipsis-v.png" alt="drag" style="width:40px;height:40px;"></div>
 											<div class="text-center col-lg-1 col-md-1 col-sm-1 ">
 													<img style="width: 30px;height: 30px;margin: 5px;" src="/<%= activities[i].directory + '/' + activities[i].icon %>" />
 											</div>

--- a/dashboard/views/includes/navbar.ejs
+++ b/dashboard/views/includes/navbar.ejs
@@ -8,7 +8,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" data-l10n-id="<%= module %>" href="#"></a>
+            <div class="navbar-brand" style="font-weight:500" data-l10n-id="<%= module %>"></div>
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
- In the activities view, since reordering by clicking anywhere on the row to drag feature is replaced with dragging the row by clicking on the vertical ellipsis, we need to make the cursor pointer when the user hovers on the icon such that he can know that there's an action associated with that icon.

- On the navbar, the name of the pages is a clickable link.
They're replaced with divs in this PR.

- The XO icons in some pages have cursor pointer associated with them. It makes the user think that they're buttons instead of images.
 
![Sugarizer Dashboard (22)](https://user-images.githubusercontent.com/24666770/54998773-f3a80480-4ff4-11e9-9f9d-221d4473eb92.gif)

Fixed:
![Sugarizer Dashboard (21)](https://user-images.githubusercontent.com/24666770/54999577-8ac18c00-4ff6-11e9-96c7-82aa5fe5f6ee.gif)
