### PR TITLE
Fix classroom name on view students from classroom view

### DIFF
--- a/dashboard/views/classrooms.ejs
+++ b/dashboard/views/classrooms.ejs
@@ -74,7 +74,7 @@
                                           <td><%= moment(data.classrooms[i].timestamp).calendar() %></td>
                                           <td>
                                               <% if(Array.isArray(data.classrooms[i].students) && data.classrooms[i].students.length > 0) { %>
-                                                  <a data-l10n-id="viewStudents" title="View Students" href="/dashboard/users?role=student&classid=<%- data.classrooms[i].students.join(',') %>"><span class="student-icon"></span></a>
+                                                  <a data-l10n-id="viewStudents" title="View Students" href="/dashboard/users?role=student&classroom_id=<%- data.classrooms[i]._id %>&classid=<%- data.classrooms[i].students.join(',') %>"><span class="student-icon"></span></a>
                                               <% } else { %>
                                                   <a title="View Students" style="pointer-events: none;"><span class="student-icon" style="opacity: 0.4;"></span></a>
                                               <% } %>


### PR DESCRIPTION
When navigating from Classroom view to Users view by clicking on `ViewStudents` button, the name of the Classroom is not displayed in the Classroom-Select field.

Current Behaviour:
![Sugarizer Dashboard (30)](https://user-images.githubusercontent.com/24666770/55275408-91f4dc80-530b-11e9-8d8c-6a2654e0091f.gif)

Expected Behavior:
![Sugarizer Dashboard (29)](https://user-images.githubusercontent.com/24666770/55275401-886b7480-530b-11e9-905e-66b363a06005.gif)
