### PR TITLE
Improve navigation on mobile view

### DIFF
--- a/dashboard/public/css/material-dashboard.css
+++ b/dashboard/public/css/material-dashboard.css
@@ -4848,7 +4848,17 @@ footer .btn {
   }
   .navbar-transparent {
     padding-top: 15px;
-    background-color: rgba(0, 0, 0, 0.45);
+    position: sticky;
+    top: 0px;
+    background-color: #e5e5e5 !important;
+    padding-top: 15px;
+    border-bottom: 1px solid grey !important;
+  }
+  .main-panel>.content {
+    margin-top: 35px;
+  }
+  .no-border-bottom {
+    border-bottom: 0px !important;
   }
   body {
     position: relative;

--- a/dashboard/views/login.ejs
+++ b/dashboard/views/login.ejs
@@ -1,5 +1,5 @@
 <% include includes/header %>
-<nav class="navbar navbar-transparent navbar-absolute">
+<nav class="navbar navbar-transparent navbar-absolute no-border-bottom">
     <div class="container-fluid">
         <div class="collapse navbar-collapse">
             <div class="navbar-form navbar-right">


### PR DESCRIPTION
In the mobile view, the navbar position is relative.
If a user scrolls to the bottom of the page and he wants to navigate to another view then he has to scroll back to the top of the page to access the sidebar.

Current Behavior:
![Sugarizer Dashboard (32)](https://user-images.githubusercontent.com/24666770/55288506-3f342700-53d6-11e9-969f-962cce5f1379.gif)

Patch:
![Sugarizer Dashboard (31)](https://user-images.githubusercontent.com/24666770/55288500-35aabf00-53d6-11e9-8385-087fe99d3f83.gif)
