### PR TITLE
Removed redundant translation on language change

### DIFF
--- a/dashboard/public/js/main.js
+++ b/dashboard/public/js/main.js
@@ -301,7 +301,6 @@ function onLocalized() {
 			lang.value = localStorage.getItem("languageSelection");
 		}
 		lang.onchange = function() {
-			l10n.setLanguage(this.value);
 			localStorage.setItem("languageSelection", this.value);
 			location.href = window.location.pathname + "?lang="+lang.value;
 		};


### PR DESCRIPTION
When the language is changed, the page is being translated redundantly on the front end:
1. When the language is changed, the front-end is triggered to translate the language.
2. When the page reloads, it is again translated.

Current behavior:
![final_5ca38b708aa7ac001376e2bb_865485](https://user-images.githubusercontent.com/24666770/55419609-c1694a80-5592-11e9-912d-12574d6d1188.gif)

Patch:
![final_5ca38b378473240014ed3480_56505](https://user-images.githubusercontent.com/24666770/55419631-caf2b280-5592-11e9-90be-3c68f6402ebb.gif)

Removed the `l10n` call to update the language on drop-down option change.