### PR TITLE
Package vulnerability fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,28 +120,6 @@
 				"uri-js": "^4.2.2"
 			}
 		},
-		"align-text": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"dev": true,
-			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
-			}
-		},
 		"ansi-align": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -353,8 +331,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"array-flatten": {
 			"version": "1.1.1",
@@ -989,15 +966,6 @@
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
-		"browserify-zlib": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-			"dev": true,
-			"requires": {
-				"pako": "~0.2.0"
-			}
-		},
 		"bson": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
@@ -1158,7 +1126,6 @@
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"camelcase": "^2.0.0",
 				"map-obj": "^1.0.0"
@@ -1168,8 +1135,7 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -1195,16 +1161,6 @@
 				"isurl": "^1.0.0-alpha5",
 				"tunnel-agent": "^0.6.0",
 				"url-to-options": "^1.0.1"
-			}
-		},
-		"center-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"dev": true,
-			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
 			}
 		},
 		"chai": {
@@ -1406,10 +1362,10 @@
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
-		"coffee-script": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-			"integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+		"coffeescript": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
+			"integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
 			"dev": true
 		},
 		"collection-map": {
@@ -1769,7 +1725,6 @@
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
@@ -1792,10 +1747,14 @@
 			}
 		},
 		"dateformat": {
-			"version": "1.0.2-1.2.3",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
-			"integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
-			"dev": true
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+			"integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+			"dev": true,
+			"requires": {
+				"get-stdin": "^4.0.1",
+				"meow": "^3.3.0"
+			}
 		},
 		"debug": {
 			"version": "2.6.9",
@@ -3098,45 +3057,25 @@
 			}
 		},
 		"findup-sync": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-			"integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+			"integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
 			"dev": true,
 			"requires": {
-				"glob": "~3.2.9",
-				"lodash": "~2.4.1"
+				"glob": "~5.0.0"
 			},
 			"dependencies": {
 				"glob": {
-					"version": "3.2.11",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 					"dev": true,
 					"requires": {
+						"inflight": "^1.0.4",
 						"inherits": "2",
-						"minimatch": "0.3"
-					}
-				},
-				"lodash": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-					"dev": true
-				},
-				"lru-cache": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-					"dev": true
-				},
-				"minimatch": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "2",
-						"sigmund": "~1.0.0"
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				}
 			}
@@ -3838,8 +3777,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
 			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"get-stream": {
 			"version": "4.1.0",
@@ -4078,140 +4016,69 @@
 			"dev": true
 		},
 		"grunt": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
-			"integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.4.tgz",
+			"integrity": "sha512-PYsMOrOC+MsdGEkFVwMaMyc6Ob7pKmq+deg1Sjr+vvMWp35sztfwKE7qoN51V+UEtHsyNuMcGdgMLFkBHvMxHQ==",
 			"dev": true,
 			"requires": {
-				"async": "~0.1.22",
-				"coffee-script": "~1.3.3",
-				"colors": "~0.6.2",
-				"dateformat": "1.0.2-1.2.3",
+				"coffeescript": "~1.10.0",
+				"dateformat": "~1.0.12",
 				"eventemitter2": "~0.4.13",
 				"exit": "~0.1.1",
-				"findup-sync": "~0.1.2",
-				"getobject": "~0.1.0",
-				"glob": "~3.1.21",
-				"grunt-legacy-log": "~0.1.0",
-				"grunt-legacy-util": "~0.2.0",
-				"hooker": "~0.2.3",
-				"iconv-lite": "~0.2.11",
-				"js-yaml": "~2.0.5",
-				"lodash": "~0.9.2",
-				"minimatch": "~0.2.12",
-				"nopt": "~1.0.10",
-				"rimraf": "~2.2.8",
-				"underscore.string": "~2.2.1",
-				"which": "~1.0.5"
+				"findup-sync": "~0.3.0",
+				"glob": "~7.0.0",
+				"grunt-cli": "~1.2.0",
+				"grunt-known-options": "~1.1.0",
+				"grunt-legacy-log": "~2.0.0",
+				"grunt-legacy-util": "~1.1.1",
+				"iconv-lite": "~0.4.13",
+				"js-yaml": "~3.13.0",
+				"minimatch": "~3.0.2",
+				"mkdirp": "~0.5.1",
+				"nopt": "~3.0.6",
+				"path-is-absolute": "~1.0.0",
+				"rimraf": "~2.6.2"
 			},
 			"dependencies": {
-				"argparse": {
-					"version": "0.1.16",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-					"integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
-					"dev": true,
-					"requires": {
-						"underscore": "~1.7.0",
-						"underscore.string": "~2.4.0"
-					},
-					"dependencies": {
-						"underscore.string": {
-							"version": "2.4.0",
-							"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-							"integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
-							"dev": true
-						}
-					}
-				},
-				"async": {
-					"version": "0.1.22",
-					"resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-					"integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
-					"dev": true
-				},
-				"colors": {
-					"version": "0.6.2",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-					"integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-					"dev": true
-				},
-				"esprima": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-					"integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
-					"dev": true
-				},
 				"glob": {
-					"version": "3.1.21",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-					"integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+					"version": "7.0.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+					"integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "~1.2.0",
-						"inherits": "1",
-						"minimatch": "~0.2.11"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.2",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
-				"graceful-fs": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-					"integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-					"dev": true
-				},
-				"iconv-lite": {
-					"version": "0.2.11",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-					"integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
-					"dev": true
-				},
-				"inherits": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-					"integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-					"dev": true
-				},
-				"js-yaml": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-					"integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+				"grunt-cli": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+					"integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
 					"dev": true,
 					"requires": {
-						"argparse": "~ 0.1.11",
-						"esprima": "~ 1.0.2"
+						"findup-sync": "~0.3.0",
+						"grunt-known-options": "~1.1.0",
+						"nopt": "~3.0.6",
+						"resolve": "~1.1.0"
 					}
 				},
-				"lodash": {
-					"version": "0.9.2",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-					"integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-					"dev": true
-				},
-				"lru-cache": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-					"dev": true
-				},
-				"minimatch": {
-					"version": "0.2.14",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-					"integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+				"nopt": {
+					"version": "3.0.6",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+					"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "2",
-						"sigmund": "~1.0.0"
+						"abbrev": "1"
 					}
 				},
-				"rimraf": {
-					"version": "2.2.8",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-					"dev": true
-				},
-				"which": {
-					"version": "1.0.9",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-					"integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
 					"dev": true
 				}
 			}
@@ -4253,207 +4120,72 @@
 			}
 		},
 		"grunt-contrib-uglify": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.5.1.tgz",
-			"integrity": "sha1-FfCqXo6LpCGuqYCHnuUFvHErbN4=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-4.0.1.tgz",
+			"integrity": "sha512-dwf8/+4uW1+7pH72WButOEnzErPGmtUvc8p08B0eQS/6ON0WdeQu0+WFeafaPTbbY1GqtS25lsHWaDeiTQNWPg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^0.5.1",
-				"lodash": "^2.4.1",
-				"maxmin": "^0.2.0",
-				"uglify-js": "^2.4.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-					"integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-					"integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-					"integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^1.1.0",
-						"escape-string-regexp": "^1.0.0",
-						"has-ansi": "^0.1.0",
-						"strip-ansi": "^0.3.0",
-						"supports-color": "^0.2.0"
-					}
-				},
-				"figures": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
-					}
-				},
-				"gzip-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-0.2.0.tgz",
-					"integrity": "sha1-46KhkSBf5W7jJvXCcUNd+uz7Phw=",
-					"dev": true,
-					"requires": {
-						"browserify-zlib": "^0.1.4",
-						"concat-stream": "^1.4.1"
-					}
-				},
-				"has-ansi": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-					"integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^0.2.0"
-					}
-				},
-				"lodash": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-					"dev": true
-				},
-				"maxmin": {
-					"version": "0.2.2",
-					"resolved": "https://registry.npmjs.org/maxmin/-/maxmin-0.2.2.tgz",
-					"integrity": "sha1-o2ztjMIuOrzRCM+3l6OktAJ1WT8=",
-					"dev": true,
-					"requires": {
-						"chalk": "^0.5.0",
-						"figures": "^1.0.1",
-						"gzip-size": "^0.2.0",
-						"pretty-bytes": "^0.1.0"
-					}
-				},
-				"pretty-bytes": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz",
-					"integrity": "sha1-zZApTVihyk6KXQ+5yCJZmIgazwA=",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-					"integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^0.2.1"
-					}
-				},
-				"supports-color": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-					"integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
-					"dev": true
-				}
+				"chalk": "^2.4.1",
+				"maxmin": "^2.1.0",
+				"uglify-js": "^3.5.0",
+				"uri-path": "^1.0.0"
 			}
 		},
+		"grunt-known-options": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
+			"integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
+			"dev": true
+		},
 		"grunt-legacy-log": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
-			"integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
+			"integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
 			"dev": true,
 			"requires": {
-				"colors": "~0.6.2",
-				"grunt-legacy-log-utils": "~0.1.1",
+				"colors": "~1.1.2",
+				"grunt-legacy-log-utils": "~2.0.0",
 				"hooker": "~0.2.3",
-				"lodash": "~2.4.1",
-				"underscore.string": "~2.3.3"
+				"lodash": "~4.17.5"
 			},
 			"dependencies": {
 				"colors": {
-					"version": "0.6.2",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-					"integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-					"dev": true
-				},
-				"lodash": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-					"dev": true
-				},
-				"underscore.string": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-					"integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
 					"dev": true
 				}
 			}
 		},
 		"grunt-legacy-log-utils": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
-			"integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
+			"integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
 			"dev": true,
 			"requires": {
-				"colors": "~0.6.2",
-				"lodash": "~2.4.1",
-				"underscore.string": "~2.3.3"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "0.6.2",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-					"integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-					"dev": true
-				},
-				"lodash": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-					"dev": true
-				},
-				"underscore.string": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-					"integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-					"dev": true
-				}
+				"chalk": "~2.4.1",
+				"lodash": "~4.17.10"
 			}
 		},
 		"grunt-legacy-util": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
-			"integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
+			"integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
 			"dev": true,
 			"requires": {
-				"async": "~0.1.22",
+				"async": "~1.5.2",
 				"exit": "~0.1.1",
 				"getobject": "~0.1.0",
 				"hooker": "~0.2.3",
-				"lodash": "~0.9.2",
-				"underscore.string": "~2.2.1",
-				"which": "~1.0.5"
+				"lodash": "~4.17.10",
+				"underscore.string": "~3.3.4",
+				"which": "~1.3.0"
 			},
 			"dependencies": {
 				"async": {
-					"version": "0.1.22",
-					"resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-					"integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
-					"dev": true
-				},
-				"lodash": {
-					"version": "0.9.2",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-					"integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-					"dev": true
-				},
-				"which": {
-					"version": "1.0.9",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-					"integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
 					"dev": true
 				}
 			}
@@ -4936,7 +4668,6 @@
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"repeating": "^2.0.0"
 			}
@@ -5192,7 +4923,6 @@
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -5591,12 +5321,6 @@
 				"package-json": "^4.0.0"
 			}
 		},
-		"lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-			"dev": true
-		},
 		"lazystream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -5699,9 +5423,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -5761,14 +5485,14 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
 			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"loud-rejection": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
@@ -5838,8 +5562,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"map-visit": {
 			"version": "1.0.0",
@@ -5992,7 +5715,6 @@
 			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"camelcase-keys": "^2.0.0",
 				"decamelize": "^1.1.2",
@@ -6775,12 +6497,6 @@
 				"semver": "^5.1.0"
 			}
 		},
-		"pako": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
-			"dev": true
-		},
 		"parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7200,7 +6916,6 @@
 			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"indent-string": "^2.1.0",
 				"strip-indent": "^1.0.1"
@@ -7279,7 +6994,6 @@
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
@@ -7405,15 +7119,6 @@
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-		},
-		"right-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"dev": true,
-			"requires": {
-				"align-text": "^0.1.1"
-			}
 		},
 		"rimraf": {
 			"version": "2.6.3",
@@ -7602,12 +7307,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-		},
-		"sigmund": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -8027,7 +7726,6 @@
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"get-stdin": "^4.0.1"
 			}
@@ -8405,8 +8103,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
 			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"trim-repeated": {
 			"version": "1.0.0",
@@ -8498,59 +8195,28 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "2.8.29",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
+			"integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
 			"dev": true,
 			"requires": {
-				"source-map": "~0.5.1",
-				"uglify-to-browserify": "~1.0.0",
-				"yargs": "~3.10.0"
+				"commander": "~2.20.3",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 					"dev": true
 				},
-				"cliui": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-					"dev": true,
-					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
-						"wordwrap": "0.0.2"
-					}
-				},
-				"wordwrap": {
-					"version": "0.0.2",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
-				},
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
-						"window-size": "0.1.0"
-					}
 				}
 			}
-		},
-		"uglify-to-browserify": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"dev": true,
-			"optional": true
 		},
 		"uid-safe": {
 			"version": "2.1.5",
@@ -8585,17 +8251,15 @@
 				"debug": "^2.2.0"
 			}
 		},
-		"underscore": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-			"integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-			"dev": true
-		},
 		"underscore.string": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-			"integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
-			"dev": true
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+			"integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "^1.0.3",
+				"util-deprecate": "^1.0.2"
+			}
 		},
 		"undertaker": {
 			"version": "1.2.1",
@@ -8737,6 +8401,12 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"uri-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/uri-path/-/uri-path-1.0.0.tgz",
+			"integrity": "sha1-l0fwGDWJM8Md4PzP2C0TjmcmLjI=",
+			"dev": true
 		},
 		"urix": {
 			"version": "0.1.0",
@@ -8942,12 +8612,6 @@
 			"requires": {
 				"string-width": "^2.1.1"
 			}
-		},
-		"window-size": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-			"dev": true
 		},
 		"winston": {
 			"version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
 		"apidoc": "~0.17.0",
 		"mocha": "~6.2.0",
 		"eslint": "~6.6.0",
-		"grunt": "~0.4.5",
+		"grunt": "^1.0.4",
 		"grunt-contrib-cssmin": "^3.0.0",
 		"grunt-contrib-imagemin": "^3.1.0",
-		"grunt-contrib-uglify": "~0.5.0"
+		"grunt-contrib-uglify": "^4.0.1"
 	},
 	"scripts": {
 		"test": "mocha api/test/ --timeout 20000",


### PR DESCRIPTION
`npm audit` report on dev branch:
![Screenshot from 2020-01-09 22-31-26](https://user-images.githubusercontent.com/24666770/72088536-5e31f300-3330-11ea-9214-18c13b0b15f3.png)

`npm audit` report after patch:
![Screenshot from 2020-01-09 22-31-09](https://user-images.githubusercontent.com/24666770/72088580-7dc91b80-3330-11ea-8af9-a5d9ed58cd6b.png)

npm version: 6.5.0-next.0
node version: v11.6.0

Updated `grunt` and `grunt-contrib-uglify` versions. Public resource minification seems to work fine after the update. Also updated `lodash` in `package-lock.json`.
