### PR TITLE
no-prototype-builtins error removed

### DIFF
--- a/api/controller/classrooms.js
+++ b/api/controller/classrooms.js
@@ -567,7 +567,7 @@ function formPaginatedUrl(route, params, offset, limit) {
 	params.limit = limit;
 	var str = [];
 	for (var p in params)
-		if (params.hasOwnProperty(p)) {
+		if (p && Object.prototype.hasOwnProperty.call(params, p)) {
 			str.push(p + "=" + params[p]);
 		}
 	return "?" + str.join("&");

--- a/api/controller/journal.js
+++ b/api/controller/journal.js
@@ -455,7 +455,7 @@ function formPaginatedUrl(route, params, offset, limit) {
 	params.limit = limit;
 	var str = [];
 	for (var p in params)
-		if (params.hasOwnProperty(p)) {
+		if (p && Object.prototype.hasOwnProperty.call(params, p)) {
 			str.push(encodeURIComponent(p) + "=" + encodeURIComponent(params[p]));
 		}
 	return '?' + str.join("&");

--- a/api/controller/users.js
+++ b/api/controller/users.js
@@ -244,7 +244,7 @@ function formPaginatedUrl(route, params, offset, limit) {
 	params.limit = limit;
 	var str = [];
 	for (var p in params)
-		if (params.hasOwnProperty(p)) {
+		if (p && Object.prototype.hasOwnProperty.call(params, p)) {
 			str.push((p) + "=" + (params[p]));
 		}
 	return '?' + str.join("&");

--- a/dashboard/controller/activities/util/index.js
+++ b/dashboard/controller/activities/util/index.js
@@ -35,7 +35,7 @@ exports.getUser = function(req, uid, callback) {
 exports.formQueryString = function(params) {
 	var str = [];
 	for (var p in params)
-		if (params.hasOwnProperty(p)) {
+		if (p && Object.prototype.hasOwnProperty.call(params, p)) {
 			str.push(encodeURIComponent(p) + "=" + encodeURIComponent(params[p]));
 		}
 	return '?' + str.join("&");

--- a/dashboard/controller/stats/util/index.js
+++ b/dashboard/controller/stats/util/index.js
@@ -21,7 +21,7 @@ exports.getHowUserLaunchActivity = function(req, res) {
 
 			var d = {};
 			for (var i = 0; i < data.length; i++) {
-				if (!d.hasOwnProperty(data[i].event_object)) {
+				if (data[i].event_object && !Object.prototype.hasOwnProperty.call(d, data[i].event_object)) {
 					d[data[i].event_object] = 1;
 				} else {
 					d[data[i].event_object]++;
@@ -279,7 +279,7 @@ exports.getMostActiveClassrooms = function(req, res) {
 			var studentRequestCount = 0;
 			var studentResponseCount = 0;
 			for (var key in studentsHash) {
-				if (key && studentsHash.hasOwnProperty(key) && typeof studentsHash[key] == 'object') {
+				if (key && Object.prototype.hasOwnProperty.call(studentsHash, key) && typeof studentsHash[key] == 'object') {
 					studentRequestCount++;
 					request({
 						headers: common.getHeaders(req),
@@ -317,7 +317,7 @@ exports.getMostActiveClassrooms = function(req, res) {
 		var journalRequestCount = 0;
 		var journalResponseCount = 0;
 		for (var key in studentsHash) {
-			if (studentsHash.hasOwnProperty(key) && typeof studentsHash[key] == 'object' && studentsHash[key].jid) {
+			if (key && Object.prototype.hasOwnProperty.call(studentsHash, key) && typeof studentsHash[key] == 'object' && studentsHash[key].jid) {
 				makeJournalRequest(key);
 			}
 		}

--- a/dashboard/public/js/main.js
+++ b/dashboard/public/js/main.js
@@ -814,7 +814,7 @@ function sortBy(params) {
 
 	var url = location.origin + location.pathname + '?';
 	for (var key in query) {
-		if (key && query.hasOwnProperty(key)) {
+		if (key && Object.prototype.hasOwnProperty.call(query, key)) {
 			var val = query[key];
 			url += key + '=' + val + '&';
 		}


### PR DESCRIPTION
ESLint restricts the use of [Object.prototypes builtins directly](https://eslint.org/docs/rules/no-prototype-builtins).

On running `npm run lint`:
![Screenshot from 2020-01-15 17-36-39](https://user-images.githubusercontent.com/24666770/72433056-961cb880-37be-11ea-9da5-869e7dd209a7.png)

Running tests after fixing the issue:
![Screenshot from 2020-01-15 17-36-49](https://user-images.githubusercontent.com/24666770/72433173-c8c6b100-37be-11ea-9f4b-23a844be1907.png)
