### PR TITLE
[Issue #142 fix] Fixed query retention after language switch

### DIFF
--- a/dashboard/public/js/main.js
+++ b/dashboard/public/js/main.js
@@ -639,8 +639,7 @@ function onLocalized() {
 			if(searchQuery.length == 0) {
 				//query empty
 				searchQuery = '?lang=' + lang.value;
-			}
-			if(searchQuery.indexOf('lang=') != -1) {
+			} else if(searchQuery.indexOf('lang=') != -1) {
 				// query contains the 'lang=' parameter
 				searchQuery = searchQuery.replace(/lang=[a-z][a-z]/, 'lang=' + lang.value);
 			} else {

--- a/dashboard/public/js/main.js
+++ b/dashboard/public/js/main.js
@@ -635,7 +635,19 @@ function onLocalized() {
 		}
 		lang.onchange = function() {
 			localStorage.setItem("languageSelection", this.value);
-			location.href = window.location.pathname + "?lang="+lang.value;
+			var searchQuery = location.search;
+			if(searchQuery.length == 0) {
+				//query empty
+				searchQuery = '?lang=' + lang.value;
+			}
+			if(searchQuery.indexOf('lang=') != -1) {
+				// query contains the 'lang=' parameter
+				searchQuery = searchQuery.replace(/lang=[a-z][a-z]/, 'lang=' + lang.value);
+			} else {
+				// query does not contain 'lang=' parameter
+				searchQuery += '&lang=' + lang.value;
+			}
+			location.href = window.location.pathname + searchQuery;
 		};
 	}
 }


### PR DESCRIPTION
Fixes #142.
On localization, I'm taking the current query and modifying it to update the language. I handled all three cases:
1. Query string empty (appending the lang)
2. Query non-empty but does not contain lang parameter (adding lang)
3. Query non-empty and contains lang parameter (Updating lang using regex)

![langSwitchNavFix2](https://user-images.githubusercontent.com/40134655/76440805-67991380-63e4-11ea-8313-7aec9d18f106.gif)

@NikhilM98 I believe this solution would not have any unexpected results as it's basically similar to refreshing the page, which was already taking place in case of language switching. The other query parameters stay the same regardless of the language chosen, hence not impacting the query search.

Please review @llaske, @NikhilM98 and @ashish0910.
