### PR TITLE
Start tutorial from beginning in journal view

### DIFF
--- a/dashboard/public/js/main.js
+++ b/dashboard/public/js/main.js
@@ -795,6 +795,10 @@ function sortBy(params) {
 
 function launchTutorial() {
 	if (window.currTour && typeof window.currTour.restart == "function") {
+		if (window.location.pathname.substr(0,19) == "/dashboard/journal/") {
+			localStorage.removeItem('journal1_end');
+			localStorage.removeItem('journal1_current_step');
+		}
 		window.currTour.restart();
 	}
 }


### PR DESCRIPTION
In the Journal view, the tutorial starts from step 3 when we try to restart the tutorial.

Expected behaviour:
![Screenshot from 2020-04-03 04-26-17](https://user-images.githubusercontent.com/24666770/78307660-0b995900-7564-11ea-84a9-7b72f15f153a.png)

Current behaviour:
![Screenshot from 2020-04-03 04-26-27](https://user-images.githubusercontent.com/24666770/78307676-17851b00-7564-11ea-8634-0584031b9bf6.png)

