### PR TITLE
ansible package for deployment to localhost

### DIFF
--- a/ansible/deploy-to-localhost/get-dependencies.sh
+++ b/ansible/deploy-to-localhost/get-dependencies.sh
@@ -1,0 +1,11 @@
+apt-get update && apt-get upgrade && apt-get dist-upgrade && apt-get autoremove
+apt-get install -y python3 python3-pip
+
+apt install -y git
+
+pip3 install ansible
+
+curl -fsSL https://get.docker.com/ | sh
+
+pip3 install docker
+pip3 install docker-compose

--- a/ansible/deploy-to-localhost/install.yml
+++ b/ansible/deploy-to-localhost/install.yml
@@ -7,10 +7,41 @@
         repo: https://github.com/llaske/sugarizer
         dest: ../../../sugarizer
         version: "HEAD"
+    
     - name: Generating Docker Compose File
       shell: sh generate-docker-compose.sh
       args:
         chdir: ../..
+
+    - name: Destroying existing services
+      docker_compose:
+        project_src: ../../
+        state: absent
+
+    - name: Check port 8080
+      wait_for:
+        port: 8080
+        delay: 5
+        timeout: 10
+      register: port_8080_check
+      ignore_errors: yes
+
+    - name: kill service on 8080
+      shell: fuser -k 8080/tcp
+      when: port_8080_check.failed == false
+    
+    - name: Check port 8039
+      wait_for:
+        port: 8039
+        delay: 5
+        timeout: 10
+      register: port_8039_check
+      ignore_errors: yes
+
+    - name: kill service on 8039
+      shell: fuser -k 8039/tcp
+      when: port_8080_check.failed == false
+
     - name: Start Sugarizer Sever
       docker_compose:
         project_src: ../../

--- a/ansible/deploy-to-localhost/install.yml
+++ b/ansible/deploy-to-localhost/install.yml
@@ -1,0 +1,19 @@
+- name: create directory
+  hosts: localhost
+  become: yes
+  tasks:
+    - name: Cloning Sguarizer Client repository from github
+      git: 
+        repo: https://github.com/llaske/sugarizer
+        dest: ../../../sugarizer
+        version: "HEAD"
+    - name: Generating Docker Compose File
+      shell: sh generate-docker-compose.sh
+      args:
+        chdir: ../..
+    - name: Start Sugarizer Sever
+      docker_compose:
+        project_src: ../../
+      register: output
+    - debug:
+        var: output

--- a/ansible/docs/ansible-deploy-to-localhost.md
+++ b/ansible/docs/ansible-deploy-to-localhost.md
@@ -1,0 +1,8 @@
+**Step 1** - Clone the sugarizer-server repository
+    git clone --single-branch --branch genericAnsible https://github.com/ksraj123/sugarizer-server.git
+
+**Step 2** - Execute `get-dependencies` script to install dependencies
+    sudo sh ansible/deploy-to-localhost/get-dependencies.sh
+
+**Step 3** - Execute the playbook, provide the password of your user account, omit `-e` flag if there is no password
+    ansible-playbook ansible/deploy-to-localhost/install.yml -e "ansible_become_pass=<Password here>"

--- a/ansible/docs/ansible-deploy-to-localhost.md
+++ b/ansible/docs/ansible-deploy-to-localhost.md
@@ -6,3 +6,5 @@
 
 **Step 3** - Execute the playbook, provide the password of your user account, omit `-e` flag if there is no password
     ansible-playbook ansible/deploy-to-localhost/install.yml -e "ansible_become_pass=<Password here>"
+
+Sugarizer server will be accessible at localhost:8080 or 127.0.0.1:8080


### PR DESCRIPTION
After discussions in issue #256 a simple ansible package for generic deployment to localhost is created, #257 proposes a package for deployment to GCP.
Docker method is adopted here for deployment, please following steps documented in `ansible/docs/ansible-deploy-to-localhost.md` to test this. 
But the package is as good as executing a script.
Suggestions requested on what more can be done.