### PR TITLE
Replace request with superagent

### DIFF
--- a/dashboard/controller/activities/index.js
+++ b/dashboard/controller/activities/index.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../helper/common'),
 	fakeLaunch = require('./fakeLaunch'),
 	launch = require('./launch');
@@ -24,36 +24,34 @@ exports.index = function(req, res) {
 	}
 
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/activities')
+		.set(common.getHeaders(req))
+		.query({
 			sort: sort,
 			name: (req.query.search ? req.query.search.trim() : undefined)
-		},
-		uri: common.getAPIUrl(req) + 'api/v1/activities'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
+		})
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
 
-			// send to activities page
-			res.render('activities', {
-				module: 'activities',
-				activities: body,
-				headers: common.getHeaders(req),
-				account: req.session.user,
-				url: common.getAPIUrl(req),
-				search: (req.query.search ? req.query.search.trim() : ''),
-				server: ini.information
-			});
-
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-			return res.redirect('/dashboard/activities');
-		}
-	});
+				// send to activities page
+				res.render('activities', {
+					module: 'activities',
+					activities: response.body,
+					headers: common.getHeaders(req),
+					account: req.session.user,
+					url: common.getAPIUrl(req),
+					search: (req.query.search ? req.query.search.trim() : ''),
+					server: ini.information
+				});
+	
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+				return res.redirect('/dashboard/activities');
+			}
+		});
 };
 
 exports.fakeLaunch = fakeLaunch;

--- a/dashboard/controller/activities/launch.js
+++ b/dashboard/controller/activities/launch.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../helper/common');
 
 var _util = require('./util'),
@@ -18,110 +18,109 @@ module.exports = function launch(req, res) {
 	}
 
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/journal/' + req.params.jid)
+		.set(common.getHeaders(req))
+		.query({
 			fields: 'text,metadata',
 			oid: req.query.oid
-		},
-		uri: common.getAPIUrl(req) + 'api/v1/journal/' + req.params.jid
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			var ver = parseFloat(body.version);
-
-			//validate
-			if (body.entries.length == 0) {
-				req.flash('errors', {
-					msg: common.l10n.get('ObjectNotFound')
-				});
-				return res.redirect('/dashboard/' + (req.query.source ? req.query.source : 'journal'));
-			}
-
-			// process data and create context
-			var lsObj = {};
-
-			if (ver > 1.1) {
-				lsObj['sugar_datastoretext_' + body.entries[0].objectId] = body.entries[0].text;
-			} else {
-				lsObj['sugar_datastoretext_' + body.entries[0].objectId] = JSON.stringify(body.entries[0].text);
-			}
-			
-			
-			if (ver > 1.1) {
-				body.entries[0].text = {
-					link: body.entries[0].objectId
-				};
-			} else {
-				body.entries[0].text = {
-					link: 'sugar_datastoretext_' + body.entries[0].objectId
-				};
-			}
-			
-			lsObj['sugar_datastore_' + body.entries[0].objectId] = JSON.stringify(body.entries[0]);
-
-			//sugar settings
-			lsObj['sugar_settings'] = {};
-
-			// get user data
-			getUser(req, body.entries[0].metadata.user_id, function(user) {
-
-				//set fields
-				lsObj['sugar_settings'].name = user ? user.name : req.session.user.user.name;
-				lsObj['sugar_settings'].color = 128;
-				lsObj['sugar_settings'].colorvalue = (user && user.color) ? user.color : req.session.user.user.color ? req.session.user.user.color : {
-					"stroke": "#005FE4",
-					"fill": "#FF2B34"
-				};
-				lsObj['sugar_settings'].connected = false;
-				lsObj['sugar_settings'].language = user ? user.language : req.query.lang ? req.query.lang : "en";
-				lsObj['sugar_settings'].networkId = body.entries[0].metadata.user_id;
-				lsObj['sugar_settings'].server = null;
-				lsObj['sugar_settings'].view = 0;
-				lsObj['sugar_settings'].activities = [];
-
-				if (req.query.mode == 'download' || body.entries[0].metadata.mimetype == "application/pdf") {
-					return res.json({
-						lsObj: lsObj,
-						version: ver,
-						objectId: body.entries[0].objectId
+		})
+		.end(function (error, response) {
+			var body = response.body;
+			if (response.statusCode == 200) {
+				var ver = parseFloat(body.version);
+	
+				//validate
+				if (body.entries.length == 0) {
+					req.flash('errors', {
+						msg: common.l10n.get('ObjectNotFound')
 					});
-				} else if (!body.entries[0].metadata.activity) {
-					return res.json({
-						error: common.l10n.get('NoLinkedActivityFound')
-					});
+					return res.redirect('/dashboard/' + (req.query.source ? req.query.source : 'journal'));
 				}
-				getActivity(req, body.entries[0].metadata.activity, function(activity) {
-					if (!activity) {
+	
+				// process data and create context
+				var lsObj = {};
+	
+				if (ver > 1.1) {
+					lsObj['sugar_datastoretext_' + body.entries[0].objectId] = body.entries[0].text;
+				} else {
+					lsObj['sugar_datastoretext_' + body.entries[0].objectId] = JSON.stringify(body.entries[0].text);
+				}
+				
+				
+				if (ver > 1.1) {
+					body.entries[0].text = {
+						link: body.entries[0].objectId
+					};
+				} else {
+					body.entries[0].text = {
+						link: 'sugar_datastoretext_' + body.entries[0].objectId
+					};
+				}
+				
+				lsObj['sugar_datastore_' + body.entries[0].objectId] = JSON.stringify(body.entries[0]);
+	
+				//sugar settings
+				lsObj['sugar_settings'] = {};
+	
+				// get user data
+				getUser(req, body.entries[0].metadata.user_id, function(user) {
+	
+					//set fields
+					lsObj['sugar_settings'].name = user ? user.name : req.session.user.user.name;
+					lsObj['sugar_settings'].color = 128;
+					lsObj['sugar_settings'].colorvalue = (user && user.color) ? user.color : req.session.user.user.color ? req.session.user.user.color : {
+						"stroke": "#005FE4",
+						"fill": "#FF2B34"
+					};
+					lsObj['sugar_settings'].connected = false;
+					lsObj['sugar_settings'].language = user ? user.language : req.query.lang ? req.query.lang : "en";
+					lsObj['sugar_settings'].networkId = body.entries[0].metadata.user_id;
+					lsObj['sugar_settings'].server = null;
+					lsObj['sugar_settings'].view = 0;
+					lsObj['sugar_settings'].activities = [];
+	
+					if (req.query.mode == 'download' || body.entries[0].metadata.mimetype == "application/pdf") {
+						return res.json({
+							lsObj: lsObj,
+							version: ver,
+							objectId: body.entries[0].objectId
+						});
+					} else if (!body.entries[0].metadata.activity) {
 						return res.json({
 							error: common.l10n.get('NoLinkedActivityFound')
 						});
 					}
-					
-					activity.instances = [body.entries[0]];
-					lsObj['sugar_settings'].activities.push(activity);
-					lsObj['sugar_settings'] = JSON.stringify(lsObj['sugar_settings']);
-
-					//launch url
-					res.json({
-						lsObj: lsObj,
-						url: '/' + activity.directory + '/index.html' + formQueryString({
-							aid: body.entries[0].metadata.activity_id,
-							a: activity.id,
-							o: body.entries[0].objectId,
-							n: activity.name
-						}),
-						version: ver,
-						objectId: body.entries[0].objectId
+					getActivity(req, body.entries[0].metadata.activity, function(activity) {
+						if (!activity) {
+							return res.json({
+								error: common.l10n.get('NoLinkedActivityFound')
+							});
+						}
+						
+						activity.instances = [body.entries[0]];
+						lsObj['sugar_settings'].activities.push(activity);
+						lsObj['sugar_settings'] = JSON.stringify(lsObj['sugar_settings']);
+	
+						//launch url
+						res.json({
+							lsObj: lsObj,
+							url: '/' + activity.directory + '/index.html' + formQueryString({
+								aid: body.entries[0].metadata.activity_id,
+								a: activity.id,
+								o: body.entries[0].objectId,
+								n: activity.name
+							}),
+							version: ver,
+							objectId: body.entries[0].objectId
+						});
 					});
 				});
-			});
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-			return res.redirect('/dashboard/' + (req.query.source ? req.query.source : 'journal'));
-		}
-	});
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+body.code)
+				});
+				return res.redirect('/dashboard/' + (req.query.source ? req.query.source : 'journal'));
+			}
+		});
 };

--- a/dashboard/controller/activities/util/index.js
+++ b/dashboard/controller/activities/util/index.js
@@ -1,37 +1,33 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../../helper/common');
 
 exports.getActivity = function(req, aid, callback) {
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		uri: common.getAPIUrl(req) + 'api/v1/activities/' + aid
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			// callback
-			callback(body);
-		}
-	});
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/activities/' + aid)
+		.set(common.getHeaders(req))
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				// callback
+				callback(response.body);
+			}
+		});
 };
 
 exports.getUser = function(req, uid, callback) {
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		uri: common.getAPIUrl(req) + 'api/v1/users/' + uid
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			// callback
-			callback(body);
-		} else {
-			callback();
-		}
-	});
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/users/' + uid)
+		.set(common.getHeaders(req))
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				// callback
+				callback(response.body);
+			} else {
+				callback();
+			}
+		});
 };
 
 exports.formQueryString = function(params) {

--- a/dashboard/controller/auth/postLogin.js
+++ b/dashboard/controller/auth/postLogin.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../helper/common');
 
 /**
@@ -42,29 +42,26 @@ module.exports = function postLogin(req, res) {
 	//call
 	if (!errors) {
 		// call
-		request({
-			headers: {
+		superagent
+			.post(common.getAPIUrl(req) + 'auth/login')
+			.set({
 				"content-type": "application/json",
-			},
-			json: true,
-			method: 'POST',
-			uri: common.getAPIUrl(req) + 'auth/login',
-			body: form
-		}, function(error, response, body) {
-
-			if (response.statusCode == 200) {
-				//store user and key in session
-				req.session.user = response.body;
-
-				// redirect to dashboard
-				return res.redirect('/dashboard'+(req.body && req.body.lang ? "?lang="+req.body.lang : ""));
-			} else {
-				req.flash('errors', {
-					msg: common.l10n.get('ErrorCode'+body.code)
-				});
-				return res.redirect('/dashboard/login');
-			}
-		});
+			})
+			.send(form)
+			.end(function (error, response) {
+				if (response.statusCode == 200) {
+					//store user and key in session
+					req.session.user = response.body;
+	
+					// redirect to dashboard
+					return res.redirect('/dashboard'+(req.body && req.body.lang ? "?lang="+req.body.lang : ""));
+				} else {
+					req.flash('errors', {
+						msg: common.l10n.get('ErrorCode'+response.body.code)
+					});
+					return res.redirect('/dashboard/login');
+				}
+			});
 	} else {
 		req.flash('errors', errors);
 		return res.redirect('/dashboard/login');

--- a/dashboard/controller/classrooms/addClassroom.js
+++ b/dashboard/controller/classrooms/addClassroom.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	moment = require('moment'),
 	common = require('../../helper/common'),
 	xocolors = require('../../helper/xocolors')(),
@@ -29,29 +29,27 @@ module.exports = function addClassroom(req, res) {
 
 		// call
 		if (!errors) {
-			request({
-				headers: common.getHeaders(req),
-				json: true,
-				method: 'post',
-				body: {
+			superagent
+				.post(common.getAPIUrl(req) + 'api/v1/classrooms')
+				.set(common.getHeaders(req))
+				.send({
 					classroom: JSON.stringify(req.body)
-				},
-				uri: common.getAPIUrl(req) + 'api/v1/classrooms'
-			}, function(error, response, body) {
-				if (response.statusCode == 200) {
+				})
+				.end(function (error, response) {
+					if (response.statusCode == 200) {
 
-					// send to classrooms page
-					req.flash('success', {
-						msg: common.l10n.get('ClassroomCreated', {name: req.body.name})
-					});
-					return res.redirect('/dashboard/classrooms/');
-				} else {
-					req.flash('errors', {
-						msg: common.l10n.get('ErrorCode'+body.code)
-					});
-					return res.redirect('/dashboard/classrooms/add');
-				}
-			});
+						// send to classrooms page
+						req.flash('success', {
+							msg: common.l10n.get('ClassroomCreated', {name: req.body.name})
+						});
+						return res.redirect('/dashboard/classrooms/');
+					} else {
+						req.flash('errors', {
+							msg: common.l10n.get('ErrorCode'+response.body.code)
+						});
+						return res.redirect('/dashboard/classrooms/add');
+					}
+				});
 		} else {
 			req.flash('errors', errors);
 			return res.redirect('/dashboard/classrooms/add');

--- a/dashboard/controller/classrooms/deleteClassroom.js
+++ b/dashboard/controller/classrooms/deleteClassroom.js
@@ -1,30 +1,28 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../helper/common');
 
 module.exports = function deleteClassroom(req, res) {
 
 	if (req.params.classid) {
 		var name = req.query.name || 'classroom';
-		request({
-			headers: common.getHeaders(req),
-			json: true,
-			method: 'delete',
-			uri: common.getAPIUrl(req) + 'api/v1/classrooms/' + req.params.classid
-		}, function(error, response, body) {
-			if (response.statusCode == 200) {
+		superagent
+			.delete(common.getAPIUrl(req) + 'api/v1/classrooms/' + req.params.classid)
+			.set(common.getHeaders(req))
+			.end(function (error, response) {
+				if (response.statusCode == 200) {
 
-				// send to classrooms page
-				req.flash('success', {
-					msg: common.l10n.get('ClassroomDeleted', {name: name})
-				});
-			} else {
-				req.flash('errors', {
-					msg: common.l10n.get('ErrorCode'+body.code)
-				});
-			}
-			return res.redirect('/dashboard/classrooms');
-		});
+					// send to classrooms page
+					req.flash('success', {
+						msg: common.l10n.get('ClassroomDeleted', {name: name})
+					});
+				} else {
+					req.flash('errors', {
+						msg: common.l10n.get('ErrorCode'+response.body.code)
+					});
+				}
+				return res.redirect('/dashboard/classrooms');
+			});
 	} else {
 		req.flash('errors', {
 			msg: common.l10n.get('ThereIsError')

--- a/dashboard/controller/classrooms/editClassroom.js
+++ b/dashboard/controller/classrooms/editClassroom.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	moment = require('moment'),
 	common = require('../../helper/common'),
 	xocolors = require('../../helper/xocolors')(),
@@ -30,59 +30,55 @@ module.exports = function editClassroom(req, res) {
 			var errors = req.validationErrors();
 
 			if (!errors) {
-				request({
-					headers: common.getHeaders(req),
-					json: true,
-					method: 'put',
-					body: {
+				superagent
+					.put(common.getAPIUrl(req) + 'api/v1/classrooms/' + req.params.classid)
+					.set(common.getHeaders(req))
+					.send({
 						classroom: JSON.stringify(req.body)
-					},
-					uri: common.getAPIUrl(req) + 'api/v1/classrooms/' + req.params.classid
-				}, function(error, response, body) {
-					if (response.statusCode == 200) {
+					})
+					.end(function (error, response) {
+						if (response.statusCode == 200) {
 
-						// send back
-						req.flash('success', {
-							msg: common.l10n.get('ClassroomUpdated', {name: req.body.name})
-						});
-						return res.redirect('/dashboard/classrooms/');
-					} else {
-						req.flash('errors', {
-							msg: common.l10n.get('ErrorCode'+body.code)
-						});
-						return res.redirect('/dashboard/classrooms/edit/' + req.params.classid);
-					}
-				});
+							// send back
+							req.flash('success', {
+								msg: common.l10n.get('ClassroomUpdated', {name: req.body.name})
+							});
+							return res.redirect('/dashboard/classrooms/');
+						} else {
+							req.flash('errors', {
+								msg: common.l10n.get('ErrorCode'+response.body.code)
+							});
+							return res.redirect('/dashboard/classrooms/edit/' + req.params.classid);
+						}
+					});
 			} else {
 				req.flash('errors', errors);
 				return res.redirect('/dashboard/classrooms/edit/' + req.params.classid);
 			}
 		} else {
-			request({
-				headers: common.getHeaders(req),
-				json: true,
-				method: 'get',
-				uri: common.getAPIUrl(req) + 'api/v1/classrooms/' + req.params.classid
-			}, function(error, response, body) {
-				if (response.statusCode == 200) {
+			superagent
+				.get(common.getAPIUrl(req) + 'api/v1/classrooms/' + req.params.classid)
+				.set(common.getHeaders(req))
+				.end(function (error, response) {
+					if (response.statusCode == 200) {
 
-					// send to classrooms page
-					res.render('admin/addEditClassroom', {
-						module: 'classrooms',
-						classroom: body,
-						moment: moment,
-						emoji: emoji,
-						xocolors: xocolors,
-						account: req.session.user,
-						server: classroom.ini().information
-					});
-				} else {
-					req.flash('errors', {
-						msg: common.l10n.get('ErrorCode'+body.code)
-					});
-					return res.redirect('/dashboard/classrooms');
-				}
-			});
+						// send to classrooms page
+						res.render('admin/addEditClassroom', {
+							module: 'classrooms',
+							classroom: response.body,
+							moment: moment,
+							emoji: emoji,
+							xocolors: xocolors,
+							account: req.session.user,
+							server: classroom.ini().information
+						});
+					} else {
+						req.flash('errors', {
+							msg: common.l10n.get('ErrorCode'+response.body.code)
+						});
+						return res.redirect('/dashboard/classrooms');
+					}
+				});
 		}
 	} else {
 		req.flash('errors', {

--- a/dashboard/controller/classrooms/index.js
+++ b/dashboard/controller/classrooms/index.js
@@ -47,7 +47,7 @@ exports.index = function(req, res) {
 		.set(common.getHeaders(req))
 		.query(query)
 		.end(function (error, response) {
-			if (response.status == 200) {
+			if (response.statusCode == 200) {
 
 				// send to activities page
 				res.render('classrooms', {

--- a/dashboard/controller/classrooms/index.js
+++ b/dashboard/controller/classrooms/index.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	moment = require('moment'),
 	common = require('../../helper/common'),
 	addClassroom = require('./addClassroom'),
@@ -42,33 +42,30 @@ exports.index = function(req, res) {
 		query['sort'] = req.query.sort;
 	}
 
-	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: query,
-		uri: common.getAPIUrl(req) + 'api/v1/classrooms'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/classrooms')
+		.set(common.getHeaders(req))
+		.query(query)
+		.end(function (error, response) {
+			if (response.status == 200) {
 
-			// send to activities page
-			res.render('classrooms', {
-				module: 'classrooms',
-				moment: moment,
-				query: query,
-				data: body,
-				headers: common.getHeaders(req),
-				account: req.session.user,
-				server: ini.information
-			});
-
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-		}
-	});
+				// send to activities page
+				res.render('classrooms', {
+					module: 'classrooms',
+					moment: moment,
+					query: query,
+					data: response.body,
+					headers: common.getHeaders(req),
+					account: req.session.user,
+					server: ini.information
+				});
+	
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+			}	
+		});
 };
 
 exports.addClassroom = addClassroom;

--- a/dashboard/controller/dashboard/util/index.js
+++ b/dashboard/controller/dashboard/util/index.js
@@ -1,92 +1,84 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../../helper/common');
 
 
 exports.getAllJournals = function(req, res, callback) {
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		uri: common.getAPIUrl(req) + 'api/v1/journal'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/journal')
+		.set(common.getHeaders(req))
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
 
-			//callback
-			callback(body);
-
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-		}
-	});
+				//callback
+				callback(response.body);
+	
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+			}
+		});
 };
 
 exports.getAllActivities = function(req, res, callback) {
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		uri: common.getAPIUrl(req) + 'api/v1/activities'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/activities')
+		.set(common.getHeaders(req))
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
 
-			//callback
-			callback(body);
-
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-		}
-	});
+				//callback
+				callback(response.body);
+	
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+			}
+		});
 };
 
 exports.getAllUsers = function(req, res, callback) {
 	var role = req.query.role || 'student';
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/users')
+		.set(common.getHeaders(req))
+		.query({
 			role: role,
 			sort: '-timestamp',
 			limit: 100000000
-		},
-		uri: common.getAPIUrl(req) + 'api/v1/users'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			//callback
-			callback(body);
-
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-		}
-	});
+		})
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				//callback
+				callback(response.body);
+	
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+			}
+		});
 };
 
 exports.getAllClassrooms = function(req, res, callback) {
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		uri: common.getAPIUrl(req) + 'api/v1/classrooms'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/classrooms')
+		.set(common.getHeaders(req))
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
 
-			//callback
-			callback(body);
-
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-		}
-	});
+				//callback
+				callback(response.body);
+	
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+			}
+		});
 };

--- a/dashboard/controller/graph/util/index.js
+++ b/dashboard/controller/graph/util/index.js
@@ -1,4 +1,4 @@
-var request = require('request'),
+var superagent = require('superagent'),
 	dashboard_utils = require('../../dashboard/util'),
 	moment = require('moment'),
 	common = require('../../../helper/common');
@@ -322,44 +322,40 @@ function getAllEntriesList(req, res, callback) {
 	var allEntries = [];
 
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		uri: common.getAPIUrl(req) + 'api/v1/journal/aggregate/'
-	}, function(error, response, body) {
-		//merge data
-		if (body) {
-			for (var i=0; i<body.length; i++) {
-				if (body[i] && typeof body[i].content == "object" && body[i].content.length > 0) {
-					for (var j=0; j<body[i].content.length; j++) {
-						body[i].content[j].journalId = body[i]._id;
-						body[i].content[j].shared = body[i].shared;
-						allEntries.push(body[i].content[j]);
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/journal/aggregate/')
+		.set(common.getHeaders(req))
+		.end(function (error, response) {
+			//merge data
+			if (response.body) {
+				for (var i=0; i<response.body.length; i++) {
+					if (response.body[i] && typeof response.body[i].content == "object" && response.body[i].content.length > 0) {
+						for (var j=0; j<response.body[i].content.length; j++) {
+							response.body[i].content[j].journalId = response.body[i]._id;
+							response.body[i].content[j].shared = response.body[i].shared;
+							allEntries.push(response.body[i].content[j]);
+						}
 					}
 				}
 			}
-		}
-		callback(allEntries);
-	});
+			callback(allEntries);
+		});
 }
 
 function getActivities(req, res, callback) {
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		uri: common.getAPIUrl(req) + 'api/v1/activities/'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			//store
-			callback(body);
-		} else {
-			req.flash('errors', {
-				msg: body.error
-			});
-			return res.redirect('/dashboard/journal');
-		}
-	});
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/activities/')
+		.set(common.getHeaders(req))
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				//store
+				callback(response.body);
+			} else {
+				req.flash('errors', {
+					msg: response.body.error
+				});
+				return res.redirect('/dashboard/journal');
+			}
+		});
 }

--- a/dashboard/controller/journal/deleteEntry.js
+++ b/dashboard/controller/journal/deleteEntry.js
@@ -1,35 +1,33 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../helper/common');
 
 // delete entry
 module.exports = function deleteEntry(req, res) {
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'DELETE',
-		qs: {
+	superagent
+		.delete(common.getAPIUrl(req) + 'api/v1/journal/' + req.params.jid)
+		.set(common.getHeaders(req))
+		.query({
 			oid: req.params.oid,
 			type: 'partial'
-		},
-		uri: common.getAPIUrl(req) + 'api/v1/journal/' + req.params.jid
-	}, function(error, response, body) {
-		if (req.query.uid == undefined) {
-			req.query.uid = "";
-		}
-		if (response.statusCode == 200) {
-			// return back
-			req.flash('success', {
-				msg: common.l10n.get('EntryDeleted', {activity: req.query.title})
-			});
-			return res.redirect('/dashboard/journal/' + req.params.jid + '?uid=' + req.query.uid + '&offset=' + (req.query.offset ? req.query.offset : 0) + '&limit=' + (req.query.limit ? req.query.limit : 10));
-
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-			return res.redirect('/dashboard/journal/' + req.params.jid + '?uid=' + req.query.uid + '&offset=' + (req.query.offset ? req.query.offset : 0) + '&limit=' + (req.query.limit ? req.query.limit : 10));
-		}
-	});
+		})
+		.end(function (error, response) {
+			if (req.query.uid == undefined) {
+				req.query.uid = "";
+			}
+			if (response.statusCode == 200) {
+				// return back
+				req.flash('success', {
+					msg: common.l10n.get('EntryDeleted', {activity: req.query.title})
+				});
+				return res.redirect('/dashboard/journal/' + req.params.jid + '?uid=' + req.query.uid + '&offset=' + (req.query.offset ? req.query.offset : 0) + '&limit=' + (req.query.limit ? req.query.limit : 10));
+	
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+				return res.redirect('/dashboard/journal/' + req.params.jid + '?uid=' + req.query.uid + '&offset=' + (req.query.offset ? req.query.offset : 0) + '&limit=' + (req.query.limit ? req.query.limit : 10));
+			}
+		});
 };

--- a/dashboard/controller/journal/util/index.js
+++ b/dashboard/controller/journal/util/index.js
@@ -1,91 +1,83 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../../helper/common');
 
 exports.getActivities = function(req, res, callback) {
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		uri: common.getAPIUrl(req) + 'api/v1/activities/'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			//store
-			callback(body);
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-			return res.redirect('/dashboard/journal');
-		}
-	});
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/activities/')
+		.set(common.getHeaders(req))
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				//store
+				callback(response.body);
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+				return res.redirect('/dashboard/journal');
+			}
+		});
 };
 
 exports.getJournalEntries = function(req, res, query, callback) {
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/journal/' + query.journal)
+		.set(common.getHeaders(req))
+		.query({
 			uid: query.uid,
 			offset: query.offset,
 			limit: query.limit,
 			sort: query.sort,
-		},
-		uri: common.getAPIUrl(req) + 'api/v1/journal/' + query.journal
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
+		})
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
 
-			//store
-			callback(body);
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-			return res.redirect('/dashboard/journal');
-		}
-	});
+				//store
+				callback(response.body);
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+				return res.redirect('/dashboard/journal');
+			}
+		});
 };
 
 exports.getUser = function(req, res, callback) {
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		uri: common.getAPIUrl(req) + 'api/v1/users/' + req.query.uid
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/users/' + req.query.uid)
+		.set(common.getHeaders(req))
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
 
-			callback(body);
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-			return res.redirect('/dashboard/journal');
-		}
-	});
+				callback(response.body);
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+				return res.redirect('/dashboard/journal');
+			}
+		});
 };
 
 exports.getSharedJournalId = function(req, res, callback) {
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/journal')
+		.set(common.getHeaders(req))
+		.query({
 			type: "shared"
-		},
-		uri: common.getAPIUrl(req) + 'api/v1/journal'
-	}, function(error, response, body) {
-		if (response.statusCode == 200 && body && body.length > 0 && body[0]._id) {
-			callback(body[0]._id);
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-			return res.redirect('/dashboard/journal');
-		}
-	});
+		})
+		.end(function (error, response) {
+			if (response.statusCode == 200 && response.body && response.body.length > 0 && response.body[0]._id) {
+				callback(response.body[0]._id);
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+				return res.redirect('/dashboard/journal');
+			}
+		});
 };

--- a/dashboard/controller/stats/addChart.js
+++ b/dashboard/controller/stats/addChart.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	moment = require('moment'),
 	common = require('../../helper/common'),
 	chartList = require('./util/chartList')();
@@ -40,29 +40,27 @@ module.exports = function addChart(req, res) {
 
 		// call
 		if (!errors) {
-			request({
-				headers: common.getHeaders(req),
-				json: true,
-				method: 'post',
-				body: {
+			superagent
+				.post(common.getAPIUrl(req) + 'api/v1/charts')
+				.set(common.getHeaders(req))
+				.send({
 					chart: JSON.stringify(req.body)
-				},
-				uri: common.getAPIUrl(req) + 'api/v1/charts'
-			}, function(error, response, body) {
-				if (response.statusCode == 200) {
+				})
+				.end(function (error, response) {
+					if (response.statusCode == 200) {
 
-					// send to classrooms page
-					req.flash('success', {
-						msg: common.l10n.get('ChartAdded', {title: req.body.title})
-					});
-					return res.redirect('/dashboard/stats/list');
-				} else {
-					req.flash('errors', {
-						msg: common.l10n.get('ErrorCode'+body.code)
-					});
-					return res.redirect('/dashboard/stats/add');
-				}
-			});
+						// send to classrooms page
+						req.flash('success', {
+							msg: common.l10n.get('ChartAdded', {title: req.body.title})
+						});
+						return res.redirect('/dashboard/stats/list');
+					} else {
+						req.flash('errors', {
+							msg: common.l10n.get('ErrorCode'+response.body.code)
+						});
+						return res.redirect('/dashboard/stats/add');
+					}
+				});
 		} else {
 			req.flash('errors', errors);
 			return res.redirect('/dashboard/stats/add');

--- a/dashboard/controller/stats/deleteChart.js
+++ b/dashboard/controller/stats/deleteChart.js
@@ -1,30 +1,28 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../helper/common');
 
 module.exports = function deleteChart(req, res) {
 
 	if (req.params.chartid) {
 		var title = req.query.title || 'chart';
-		request({
-			headers: common.getHeaders(req),
-			json: true,
-			method: 'delete',
-			uri: common.getAPIUrl(req) + 'api/v1/charts/' + req.params.chartid
-		}, function(error, response, body) {
-			if (response.statusCode == 200) {
+		superagent
+			.delete(common.getAPIUrl(req) + 'api/v1/charts/' + req.params.chartid)
+			.set(common.getHeaders(req))
+			.end(function (error, response) {
+				if (response.statusCode == 200) {
 
-				// send to charts page
-				req.flash('success', {
-					msg: common.l10n.get('ChartDeleted', {title: title})
-				});
-			} else {
-				req.flash('errors', {
-					msg: common.l10n.get('ErrorCode'+body.code)
-				});
-			}
-			return res.redirect('/dashboard/stats/list');
-		});
+					// send to charts page
+					req.flash('success', {
+						msg: common.l10n.get('ChartDeleted', {title: title})
+					});
+				} else {
+					req.flash('errors', {
+						msg: common.l10n.get('ErrorCode'+response.body.code)
+					});
+				}
+				return res.redirect('/dashboard/stats/list');
+			});
 	} else {
 		req.flash('errors', {
 			msg: common.l10n.get('ThereIsError')

--- a/dashboard/controller/stats/index.js
+++ b/dashboard/controller/stats/index.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../helper/common'),
 	getGraph = require('./getGraph'),
 	addChart = require('./addChart'),
@@ -29,31 +29,29 @@ exports.index = function(req, res) {
 		chartDic[chartList[i].key] = chartList[i];
 	}
 
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/charts')
+		.set(common.getHeaders(req))
+		.query({
 			hidden: false,
-		},
-		uri: common.getAPIUrl(req) + 'api/v1/charts'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			res.render('admin/stats', {
-				title: 'stats',
-				module: 'stats',
-				charts: body.charts,
-				chartList: chartDic,
-				account: req.session.user,
-				server: ini.information
-			});
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-			return res.redirect('/dashboard');
-		}
-	});
+		})
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				res.render('admin/stats', {
+					title: 'stats',
+					module: 'stats',
+					charts: response.body.charts,
+					chartList: chartDic,
+					account: req.session.user,
+					server: ini.information
+				});
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+				return res.redirect('/dashboard');
+			}
+		});
 };
 
 exports.getGraph = getGraph;

--- a/dashboard/controller/stats/listCharts.js
+++ b/dashboard/controller/stats/listCharts.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../helper/common'),
 	chartList = require('./util/chartList')();
 
@@ -19,29 +19,27 @@ module.exports = function listCharts(req, res) {
 	}
 
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		uri: common.getAPIUrl(req) + 'api/v1/charts'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			// send to list charts page
-			res.render('admin/listCharts', {
-				module: 'stats',
-				charts: body.charts,
-				headers: common.getHeaders(req),
-				chartList: chartDic,
-				account: req.session.user,
-				url: common.getAPIUrl(req),
-				server: stats.ini().information
-			});
-
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-			return res.redirect('/dashboard/stats');
-		}
-	});
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/charts')
+		.set(common.getHeaders(req))
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				// send to list charts page
+				res.render('admin/listCharts', {
+					module: 'stats',
+					charts: response.body.charts,
+					headers: common.getHeaders(req),
+					chartList: chartDic,
+					account: req.session.user,
+					url: common.getAPIUrl(req),
+					server: stats.ini().information
+				});
+	
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+				return res.redirect('/dashboard/stats');
+			}
+		});
 };

--- a/dashboard/controller/stats/util/index.js
+++ b/dashboard/controller/stats/util/index.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	moment = require('moment'),
 	common = require('../../../helper/common'),
 	graph = require('../../../controller/graph');
@@ -252,66 +252,63 @@ exports.getHowManyEntriesByJournal = function(req, res) {
 
 exports.getMostActiveClassrooms = function(req, res) {
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/classrooms')
+		.set(common.getHeaders(req))
+		.query({
 			'limit': 100000000
-		},
-		uri: common.getAPIUrl(req) + 'api/v1/classrooms'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			var classrooms = body.classrooms;
-			var studentsHash = {};
-			for (var i=0; i<classrooms.length; i++) {
-				if (classrooms[i] && typeof classrooms[i].students == 'object' && classrooms[i].students.length > 0) {
-					for (var j=0; j<classrooms[i].students.length; j++) {
-						studentsHash[classrooms[i].students[j]] = {
-							jid: '',
-							name: '',
-							_id: classrooms[i].students[j],
-							entries: 0
-						};
+		})
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				var classrooms = response.body.classrooms;
+				var studentsHash = {};
+				for (var i=0; i<classrooms.length; i++) {
+					if (classrooms[i] && typeof classrooms[i].students == 'object' && classrooms[i].students.length > 0) {
+						for (var j=0; j<classrooms[i].students.length; j++) {
+							studentsHash[classrooms[i].students[j]] = {
+								jid: '',
+								name: '',
+								_id: classrooms[i].students[j],
+								entries: 0
+							};
+						}
 					}
 				}
-			}
-			var studentRequestCount = 0;
-			var studentResponseCount = 0;
-			for (var key in studentsHash) {
-				if (key && Object.prototype.hasOwnProperty.call(studentsHash, key) && typeof studentsHash[key] == 'object') {
-					studentRequestCount++;
-					request({
-						headers: common.getHeaders(req),
-						json: true,
-						method: 'get',
-						uri: common.getAPIUrl(req) + 'api/v1/users/' + key
-					}, function(error, response, user) {
-						if (error) {
-							studentResponseCount++;
-							if (studentRequestCount == studentResponseCount) fetchEntries(studentsHash, classrooms);
-						} else if (response.statusCode == 200) {
-							studentResponseCount++;
-							studentsHash[user._id].jid = user.private_journal;
-							studentsHash[user._id].name = user.name;
-							studentsHash[user._id]._id = user._id;
-							if (studentRequestCount == studentResponseCount) fetchEntries(studentsHash, classrooms);
-						} else {
-							studentResponseCount++;
-							if (studentRequestCount == studentResponseCount) fetchEntries(studentsHash, classrooms);
-						}
-					});
+				var studentRequestCount = 0;
+				var studentResponseCount = 0;
+				for (var key in studentsHash) {
+					if (key && Object.prototype.hasOwnProperty.call(studentsHash, key) && typeof studentsHash[key] == 'object') {
+						studentRequestCount++;
+						superagent
+							.get(common.getAPIUrl(req) + 'api/v1/users/' + key)
+							.set(common.getHeaders(req))
+							.end(function (error, response) {
+								var user = response.body;
+								if (error) {
+									studentResponseCount++;
+									if (studentRequestCount == studentResponseCount) fetchEntries(studentsHash, classrooms);
+								} else if (response.statusCode == 200) {
+									studentResponseCount++;
+									studentsHash[user._id].jid = user.private_journal;
+									studentsHash[user._id].name = user.name;
+									studentsHash[user._id]._id = user._id;
+									if (studentRequestCount == studentResponseCount) fetchEntries(studentsHash, classrooms);
+								} else {
+									studentResponseCount++;
+									if (studentRequestCount == studentResponseCount) fetchEntries(studentsHash, classrooms);
+								}
+							});
+					}
 				}
+	
+				if (studentRequestCount == 0) fetchEntries(studentsHash, classrooms);
+	
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
 			}
-
-			if (studentRequestCount == 0) fetchEntries(studentsHash, classrooms);
-
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-		}
-	});
+		});
 
 	function fetchEntries(studentsHash, classrooms) {
 		var journalRequestCount = 0;
@@ -324,30 +321,28 @@ exports.getMostActiveClassrooms = function(req, res) {
 
 		function makeJournalRequest(thisKey) {
 			journalRequestCount++;
-			request({
-				headers: common.getHeaders(req),
-				json: true,
-				method: 'GET',
-				qs: {
+			superagent
+				.get(common.getAPIUrl(req) + 'api/v1/journal/' + studentsHash[thisKey].jid)
+				.set(common.getHeaders(req))
+				.query({
 					uid: thisKey,
 					limit: 100000000
-				},
-				uri: common.getAPIUrl(req) + 'api/v1/journal/' + studentsHash[thisKey].jid
-			}, function(error, response, body) {
-				if (error) {
-					journalResponseCount++;
-					if (journalRequestCount == journalResponseCount) createResponse(studentsHash, classrooms);
-				} else if (response.statusCode == 200) {
-					journalResponseCount++;
-					if (body.entries && body.entries.length > 0) {
-						studentsHash[thisKey].entries = body.entries.length;
+				})
+				.end(function (error, response) {
+					if (error) {
+						journalResponseCount++;
+						if (journalRequestCount == journalResponseCount) createResponse(studentsHash, classrooms);
+					} else if (response.statusCode == 200) {
+						journalResponseCount++;
+						if (response.body.entries && response.body.entries.length > 0) {
+							studentsHash[thisKey].entries = response.body.entries.length;
+						}
+						if (journalRequestCount == journalResponseCount) createResponse(studentsHash, classrooms);
+					} else {
+						journalResponseCount++;
+						if (journalRequestCount == journalResponseCount) createResponse(studentsHash, classrooms);
 					}
-					if (journalRequestCount == journalResponseCount) createResponse(studentsHash, classrooms);
-				} else {
-					journalResponseCount++;
-					if (journalRequestCount == journalResponseCount) createResponse(studentsHash, classrooms);
-				}
-			});
+				});
 			if (journalRequestCount == 0) createResponse(studentsHash, classrooms);
 		}
 	}
@@ -432,70 +427,68 @@ exports.getClassroomByStudents = function(req, res) {
 		}
 	}
 
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/classrooms')
+		.set(common.getHeaders(req))
+		.query({
 			'limit': 100000000
-		},
-		uri: common.getAPIUrl(req) + 'api/v1/classrooms'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			var classrooms = body.classrooms;
-			for (var i=0; i<classrooms.length; i++) {
-				if (classrooms[i] && typeof classrooms[i].students == 'object' && classrooms[i].students.length >= 0) {
-					classrooms[i].count = classrooms[i].students.length;
-				}
-			}
-
-			classrooms.sort(compare);
-			classrooms.splice(5);
-
-			var dataset = [];
-			var labels = [];
-			for (var i=0; i<classrooms.length; i++) {
-				if (classrooms[i].count > 0) {
-					dataset.push(classrooms[i].count);
-					labels.push(classrooms[i].name);
-				} else {
-					break;
-				}
-			}
-
-			return res.json({
-				data: {
-					labels: labels,
-					datasets: [{
-						label: common.l10n.get('CountStudents'),
-						data: dataset,
-						backgroundColor: [
-							'rgba(155, 99, 132, 0.8)',
-							'rgba(54, 162, 235, 0.8)',
-							'rgba(255, 206, 86, 0.8)',
-							'rgba(75, 192, 192, 0.8)',
-							'rgba(153, 102, 255, 0.8)'
-						]
-					}]
-				},
-				element: req.query.element,
-				graph: 'bar',
-				options: {
-					scales: {
-						yAxes: [{
-							ticks: {
-								min: 0
-							}
-						}]
+		})
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				var classrooms = response.body.classrooms;
+				for (var i=0; i<classrooms.length; i++) {
+					if (classrooms[i] && typeof classrooms[i].students == 'object' && classrooms[i].students.length >= 0) {
+						classrooms[i].count = classrooms[i].students.length;
 					}
 				}
-			});
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-		}
-	});
+	
+				classrooms.sort(compare);
+				classrooms.splice(5);
+	
+				var dataset = [];
+				var labels = [];
+				for (var i=0; i<classrooms.length; i++) {
+					if (classrooms[i].count > 0) {
+						dataset.push(classrooms[i].count);
+						labels.push(classrooms[i].name);
+					} else {
+						break;
+					}
+				}
+	
+				return res.json({
+					data: {
+						labels: labels,
+						datasets: [{
+							label: common.l10n.get('CountStudents'),
+							data: dataset,
+							backgroundColor: [
+								'rgba(155, 99, 132, 0.8)',
+								'rgba(54, 162, 235, 0.8)',
+								'rgba(255, 206, 86, 0.8)',
+								'rgba(75, 192, 192, 0.8)',
+								'rgba(153, 102, 255, 0.8)'
+							]
+						}]
+					},
+					element: req.query.element,
+					graph: 'bar',
+					options: {
+						scales: {
+							yAxes: [{
+								ticks: {
+									min: 0
+								}
+							}]
+						}
+					}
+				});
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+			}
+		});
 };
 
 exports.getLastWeekActiveUsers = function(req, res) {
@@ -531,145 +524,139 @@ function getActiveUsersByTime(req, res) {
 
 	query['stime'] = stime;
 
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: query,
-		uri: common.getAPIUrl(req) + 'api/v1/users'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			//callback
-			var users = body.users;
-			var dataObjectByTime = {};
-			var monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-			if (req.timeLimit == "week") {
-				for (var i=7; i > 0; i--) {
-					var date  = new Date(new Date() - i * 60 * 60 * 24 * 1000);
-					var month = monthNames[date.getMonth()];
-					var dateNum  = date.getDate();
-					var year  = ('' + date.getFullYear()).slice(-2);
-					var group = month + ' ' + ((dateNum<10?'0':'') + dateNum);  + '\'' + year;
-					dataObjectByTime[group] = 0;
-				}
-
-				for (var i=0; i<users.length; i++) {
-					var date  = new Date(users[i].timestamp);
-					var value = 1;
-					var month = monthNames[date.getMonth()];
-					var dateNum  = date.getDate();
-					var year  = ('' + date.getFullYear()).slice(-2);
-					var group = month + ' ' + ((dateNum<10?'0':'') + dateNum);  + '\'' + year;
-
-					dataObjectByTime[group] = (dataObjectByTime[group] || 0) + value;
-				}
-			} else if (req.timeLimit == "month")  {
-				for (var i=30; i > 0; i--) {
-					var date  = new Date(new Date() - i * 60 * 60 * 24 * 1000);
-					var month = monthNames[date.getMonth()];
-					var dateNum  = date.getDate();
-					var year  = ('' + date.getFullYear()).slice(-2);
-					var group = month + ' ' + ((dateNum<10?'0':'') + dateNum);  + '\'' + year;
-					dataObjectByTime[group] = 0;
-				}
-
-				for (var i=0; i<users.length; i++) {
-					var date  = new Date(users[i].timestamp);
-					var value = 1;
-					var month = monthNames[date.getMonth()];
-					var dateNum  = date.getDate();
-					var year  = ('' + date.getFullYear()).slice(-2);
-					var group = month + ' ' + ((dateNum<10?'0':'') + dateNum);  + '\'' + year;
-
-					dataObjectByTime[group] = (dataObjectByTime[group] || 0) + value;
-				}
-			} else if (req.timeLimit == "year") {
-				for (var i=24; i > 0; i--) {
-					var date  = new Date(new Date() - 15 * i * 60 * 60 * 24 * 1000);
-					var month = monthNames[date.getMonth()];
-					var year  = ('' + date.getFullYear()).slice(-2);
-					var group = month + '\'' + year;
-					dataObjectByTime[group] = 0;
-				}
-
-				for (var i=0; i<users.length; i++) {
-					var date  = new Date(users[i].timestamp);
-					var value = 1;
-					var month = monthNames[date.getMonth()];
-					var year  = ('' + date.getFullYear()).slice(-2);
-					var group = month + '\'' + year;
-
-					dataObjectByTime[group] = (dataObjectByTime[group] || 0) + value;
-				}
-			}
-
-			var dataset = [];
-			var labels = [];
-			Object.keys(dataObjectByTime).map(function(group){
-				dataset.push(dataObjectByTime[group]);
-				labels.push(group);
-			});
-
-			return res.json({
-				data: {
-					labels: labels,
-					datasets: [{
-						label: common.l10n.get('CountStudents'),
-						data: dataset
-					}]
-				},
-				element: req.query.element,
-				graph: 'line',
-				options: {
-					scales: {
-						yAxes: [{
-							ticks: {
-								min: 0
-							}
-						}]
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/users')
+		.set(common.getHeaders(req))
+		.query(query)
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				//callback
+				var users = response.body.users;
+				var dataObjectByTime = {};
+				var monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+				if (req.timeLimit == "week") {
+					for (var i=7; i > 0; i--) {
+						var date  = new Date(new Date() - i * 60 * 60 * 24 * 1000);
+						var month = monthNames[date.getMonth()];
+						var dateNum  = date.getDate();
+						var year  = ('' + date.getFullYear()).slice(-2);
+						var group = month + ' ' + ((dateNum<10?'0':'') + dateNum);  + '\'' + year;
+						dataObjectByTime[group] = 0;
+					}
+	
+					for (var i=0; i<users.length; i++) {
+						var date  = new Date(users[i].timestamp);
+						var value = 1;
+						var month = monthNames[date.getMonth()];
+						var dateNum  = date.getDate();
+						var year  = ('' + date.getFullYear()).slice(-2);
+						var group = month + ' ' + ((dateNum<10?'0':'') + dateNum);  + '\'' + year;
+	
+						dataObjectByTime[group] = (dataObjectByTime[group] || 0) + value;
+					}
+				} else if (req.timeLimit == "month")  {
+					for (var i=30; i > 0; i--) {
+						var date  = new Date(new Date() - i * 60 * 60 * 24 * 1000);
+						var month = monthNames[date.getMonth()];
+						var dateNum  = date.getDate();
+						var year  = ('' + date.getFullYear()).slice(-2);
+						var group = month + ' ' + ((dateNum<10?'0':'') + dateNum);  + '\'' + year;
+						dataObjectByTime[group] = 0;
+					}
+	
+					for (var i=0; i<users.length; i++) {
+						var date  = new Date(users[i].timestamp);
+						var value = 1;
+						var month = monthNames[date.getMonth()];
+						var dateNum  = date.getDate();
+						var year  = ('' + date.getFullYear()).slice(-2);
+						var group = month + ' ' + ((dateNum<10?'0':'') + dateNum);  + '\'' + year;
+	
+						dataObjectByTime[group] = (dataObjectByTime[group] || 0) + value;
+					}
+				} else if (req.timeLimit == "year") {
+					for (var i=24; i > 0; i--) {
+						var date  = new Date(new Date() - 15 * i * 60 * 60 * 24 * 1000);
+						var month = monthNames[date.getMonth()];
+						var year  = ('' + date.getFullYear()).slice(-2);
+						var group = month + '\'' + year;
+						dataObjectByTime[group] = 0;
+					}
+	
+					for (var i=0; i<users.length; i++) {
+						var date  = new Date(users[i].timestamp);
+						var value = 1;
+						var month = monthNames[date.getMonth()];
+						var year  = ('' + date.getFullYear()).slice(-2);
+						var group = month + '\'' + year;
+	
+						dataObjectByTime[group] = (dataObjectByTime[group] || 0) + value;
 					}
 				}
-			});
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-		}
-	});
+	
+				var dataset = [];
+				var labels = [];
+				Object.keys(dataObjectByTime).map(function(group){
+					dataset.push(dataObjectByTime[group]);
+					labels.push(group);
+				});
+	
+				return res.json({
+					data: {
+						labels: labels,
+						datasets: [{
+							label: common.l10n.get('CountStudents'),
+							data: dataset
+						}]
+					},
+					element: req.query.element,
+					graph: 'line',
+					options: {
+						scales: {
+							yAxes: [{
+								ticks: {
+									min: 0
+								}
+							}]
+						}
+					}
+				});
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+			}
+		});
 }
 
 function getLogsData(req, res, query, callback) {
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: query,
-		uri: common.getAPIUrl(req) + 'api/v1/stats'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			callback(body);
-		}else{
-			callback([]);
-		}
-	});
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/stats')
+		.set(common.getHeaders(req))
+		.query(query)
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				callback(response.body);
+			}else{
+				callback([]);
+			}
+		});
 }
 
 function getUsers(req, res, query, callback) {
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: query,
-		uri: common.getAPIUrl(req) + 'api/v1/users'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			//callback
-			callback(body);
-
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-		}
-	});
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/users')
+		.set(common.getHeaders(req))
+		.query(query)
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				//callback
+				callback(response.body);
+	
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+			}
+		});
 }

--- a/dashboard/controller/users/deleteUser.js
+++ b/dashboard/controller/users/deleteUser.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../helper/common');
 
 module.exports = function deleteUser(req, res) {
@@ -13,25 +13,23 @@ module.exports = function deleteUser(req, res) {
 			});
 			return res.redirect('/dashboard/users/?role='+role);
 		}
-		request({
-			headers: common.getHeaders(req),
-			json: true,
-			method: 'delete',
-			uri: common.getAPIUrl(req) + 'api/v1/users/' + req.params.uid
-		}, function(error, response, body) {
-			if (response.statusCode == 200) {
+		superagent
+			.delete(common.getAPIUrl(req) + 'api/v1/users/' + req.params.uid)
+			.set(common.getHeaders(req))
+			.end(function (error, response) {
+				if (response.statusCode == 200) {
 
-				// send to users page
-				req.flash('success', {
-					msg: common.l10n.get('UserDeleted', {name: name})
-				});
-			} else {
-				req.flash('errors', {
-					msg: common.l10n.get('ErrorCode'+body.code)
-				});
-			}
-			return res.redirect('/dashboard/users?role='+role);
-		});
+					// send to users page
+					req.flash('success', {
+						msg: common.l10n.get('UserDeleted', {name: name})
+					});
+				} else {
+					req.flash('errors', {
+						msg: common.l10n.get('ErrorCode'+response.body.code)
+					});
+				}
+				return res.redirect('/dashboard/users?role='+role);
+			});
 	} else {
 		req.flash('errors', {
 			msg: common.l10n.get('ThereIsError')

--- a/dashboard/controller/users/exportCSV.js
+++ b/dashboard/controller/users/exportCSV.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	async = require('async'),
 	common = require('../../helper/common');
 
@@ -64,121 +64,113 @@ module.exports = function exportCSV(req, res) {
     
 	async.series([
 		function(callback) {
-			request({
-				headers: common.getHeaders(req),
-				json: true,
-				method: 'GET',
-				qs: {
+			superagent
+				.get(common.getAPIUrl(req) + 'api/v1/classrooms')
+				.set(common.getHeaders(req))
+				.query({
 					limit: 100000000
-				},
-				uri: common.getAPIUrl(req) + 'api/v1/classrooms'
-			}, function(error, response, body) {
-				if (response.statusCode == 200) {
-					if (body && typeof body.classrooms == "object" && body.classrooms.length > 0) {
-						for (var i=0; i<body.classrooms.length; i++) {
-							Classrooms[body.classrooms[i]._id] = {
-								name: body.classrooms[i].name,
-								students: body.classrooms[i].students
-							};
-							if (i == body.classrooms.length - 1) callback(null);
+				})
+				.end(function (error, response) {
+					if (response.statusCode == 200) {
+						if (response.body && typeof response.body.classrooms == "object" && response.body.classrooms.length > 0) {
+							for (var i=0; i<response.body.classrooms.length; i++) {
+								Classrooms[response.body.classrooms[i]._id] = {
+									name: response.body.classrooms[i].name,
+									students: response.body.classrooms[i].students
+								};
+								if (i == response.body.classrooms.length - 1) callback(null);
+							}
+						} else {
+							callback(null);
 						}
 					} else {
 						callback(null);
 					}
-				} else {
-					callback(null);
-				}
-			});
+				});
 		},
 		function(callback) {
-			request({
-				headers: common.getHeaders(req),
-				json: true,
-				method: 'GET',
-				qs: {
+			superagent
+				.get(common.getAPIUrl(req) + 'api/v1/users')
+				.set(common.getHeaders(req))
+				.query({
 					sort: '-timestamp',
 					role: 'admin',
 					limit: 100000000
-				},
-				uri: common.getAPIUrl(req) + 'api/v1/users'
-			}, function(error, response, body) {
-				if (response.statusCode == 200) {
-					if (body.users && body.users.length) {
-						var admins = [];
-						for (var i=0; i < body.users.length; i++) {
-							admins.push(validateUser(body.users[i]));
-							if ( i == body.users.length - 1) {
-								users = users.concat(admins);
-								callback(null);
+				})
+				.end(function (error, response) {
+					if (response.statusCode == 200) {
+						if (response.body.users && response.body.users.length) {
+							var admins = [];
+							for (var i=0; i < response.body.users.length; i++) {
+								admins.push(validateUser(response.body.users[i]));
+								if (i == response.body.users.length - 1) {
+									users = users.concat(admins);
+									callback(null);
+								}
 							}
+						} else {
+							callback(null);
 						}
 					} else {
 						callback(null);
 					}
-				} else {
-					callback(null);
-				}
-			});
+				});
 		},
 		function(callback) {
-			request({
-				headers: common.getHeaders(req),
-				json: true,
-				method: 'GET',
-				qs: {
+			superagent
+				.get(common.getAPIUrl(req) + 'api/v1/users')
+				.set(common.getHeaders(req))
+				.query({
 					sort: '-timestamp',
 					role: 'student',
 					limit: 100000000
-				},
-				uri: common.getAPIUrl(req) + 'api/v1/users'
-			}, function(error, response, body) {
-				if (response.statusCode == 200) {
-					if (body.users  && body.users.length) {
-						var students = [];
-						for (var i=0; i < body.users.length; i++) {
-							students.push(validateUser(body.users[i]));
-							if ( i == body.users.length - 1) {
-								users = users.concat(students);
-								callback(null);
+				})
+				.end(function (error, response) {
+					if (response.statusCode == 200) {
+						if (response.body.users  && response.body.users.length) {
+							var students = [];
+							for (var i=0; i < response.body.users.length; i++) {
+								students.push(validateUser(response.body.users[i]));
+								if (i == response.body.users.length - 1) {
+									users = users.concat(students);
+									callback(null);
+								}
 							}
+						} else {
+							callback(null);
 						}
 					} else {
 						callback(null);
 					}
-				} else {
-					callback(null);
-				}
-			});
+				});
 		},
 		function(callback) {
-			request({
-				headers: common.getHeaders(req),
-				json: true,
-				method: 'GET',
-				qs: {
+			superagent
+				.get(common.getAPIUrl(req) + 'api/v1/users')
+				.set(common.getHeaders(req))
+				.query({
 					sort: '-timestamp',
 					role: 'teacher',
 					limit: 100000000
-				},
-				uri: common.getAPIUrl(req) + 'api/v1/users'
-			}, function(error, response, body) {
-				if (response.statusCode == 200) {
-					if (body.users && body.users.length) {
-						var teachers = [];
-						for (var i=0; i < body.users.length; i++) {
-							teachers.push(validateUser(body.users[i]));
-							if ( i == body.users.length - 1) {
-								users = users.concat(teachers);
-								callback(null);
+				})
+				.end(function (error, response) {
+					if (response.statusCode == 200) {
+						if (response.body.users && response.body.users.length) {
+							var teachers = [];
+							for (var i=0; i < response.body.users.length; i++) {
+								teachers.push(validateUser(response.body.users[i]));
+								if (i == response.body.users.length - 1) {
+									users = users.concat(teachers);
+									callback(null);
+								}
 							}
+						} else {
+							callback(null);
 						}
 					} else {
 						callback(null);
 					}
-				} else {
-					callback(null);
-				}
-			});
+				});
 		}
 	], function() {
 		if (users.length == 0) {

--- a/dashboard/controller/users/index.js
+++ b/dashboard/controller/users/index.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	moment = require('moment'),
 	common = require('../../helper/common'),
 	searchUser = require('./searchUser'),
@@ -60,37 +60,35 @@ exports.index = function(req, res) {
 	}
 
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: query,
-		uri: common.getAPIUrl(req) + 'api/v1/users'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/users')
+		.set(common.getHeaders(req))
+		.query(query)
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
 
-			// get classrooms list
-			getClassrooms(req, function(classrooms){
-
-				// send to activities page
-				res.render('users', {
-					module: 'users',
-					moment: moment,
-					query: query,
-					classrooms: classrooms,
-					classroom_id: classroom_id,
-					data: body,
-					headers: common.getHeaders(req),
-					account: req.session.user,
-					server: ini.information
+				// get classrooms list
+				getClassrooms(req, function(classrooms){
+	
+					// send to activities page
+					res.render('users', {
+						module: 'users',
+						moment: moment,
+						query: query,
+						classrooms: classrooms,
+						classroom_id: classroom_id,
+						data: response.body,
+						headers: common.getHeaders(req),
+						account: req.session.user,
+						server: ini.information
+					});
 				});
-			});
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-		}
-	});
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+			}
+		});
 };
 
 exports.searchUser = searchUser;

--- a/dashboard/controller/users/searchUser.js
+++ b/dashboard/controller/users/searchUser.js
@@ -1,5 +1,5 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../helper/common');
 
 module.exports = function searchUser(req, res) {
@@ -35,21 +35,19 @@ module.exports = function searchUser(req, res) {
 	}
 
 	// call
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: query,
-		uri: common.getAPIUrl(req) + 'api/v1/users'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
-			return res.json({
-				success: true,
-				data: body,
-				query: query
-			});
-		} else {
-			res.json({success: false, msg: common.l10n.get('ErrorCode'+body.code)});
-		}
-	});
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/users')
+		.set(common.getHeaders(req))
+		.query(query)
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
+				return res.json({
+					success: true,
+					data: response.body,
+					query: query
+				});
+			} else {
+				res.json({success: false, msg: common.l10n.get('ErrorCode'+response.body.code)});
+			}
+		});
 };

--- a/dashboard/controller/users/util/index.js
+++ b/dashboard/controller/users/util/index.js
@@ -1,26 +1,24 @@
 // include libraries
-var request = require('request'),
+var superagent = require('superagent'),
 	common = require('../../../helper/common');
 
 // private function
 exports.getClassrooms = function(req, callback) {
-	request({
-		headers: common.getHeaders(req),
-		json: true,
-		method: 'GET',
-		qs: {
+	superagent
+		.get(common.getAPIUrl(req) + 'api/v1/classrooms')
+		.set(common.getHeaders(req))
+		.query({
 			limit: 100000 // get all possible classes
-		},
-		uri: common.getAPIUrl(req) + 'api/v1/classrooms'
-	}, function(error, response, body) {
-		if (response.statusCode == 200) {
+		})
+		.end(function (error, response) {
+			if (response.statusCode == 200) {
 
-			// return list of classrooms
-			callback(body.classrooms);
-		} else {
-			req.flash('errors', {
-				msg: common.l10n.get('ErrorCode'+body.code)
-			});
-		}
-	});
+				// return list of classrooms
+				callback(response.body.classrooms);
+			} else {
+				req.flash('errors', {
+					msg: common.l10n.get('ErrorCode'+response.body.code)
+				});
+			}
+		});
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,7 @@
 			"version": "6.12.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
 			"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -357,19 +358,6 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -406,16 +394,6 @@
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
-		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-		},
-		"aws4": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -491,14 +469,6 @@
 			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
 			"requires": {
 				"safe-buffer": "5.1.2"
-			}
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"requires": {
-				"tweetnacl": "^0.14.3"
 			}
 		},
 		"bin-build": {
@@ -1074,11 +1044,6 @@
 			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
 			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
 			"dev": true
-		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"caw": {
 			"version": "2.0.1",
@@ -1694,14 +1659,6 @@
 				"type": "^1.0.1"
 			}
 		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
-		},
 		"dateformat": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -2141,15 +2098,6 @@
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
 			"dev": true
-		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
 		},
 		"ee-first": {
 			"version": "1.1.1",
@@ -2679,7 +2627,8 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -2789,15 +2738,11 @@
 				}
 			}
 		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-		},
 		"fast-deep-equal": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+			"dev": true
 		},
 		"fast-glob": {
 			"version": "2.2.7",
@@ -2839,7 +2784,8 @@
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -3032,15 +2978,11 @@
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
 		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-		},
 		"form-data": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -3196,14 +3138,6 @@
 			"resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
 			"integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
 			"dev": true
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
 		},
 		"gifsicle": {
 			"version": "4.0.1",
@@ -3531,20 +3465,6 @@
 				"duplexer": "^0.1.1"
 			}
 		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-		},
-		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-			"requires": {
-				"ajv": "^6.5.5",
-				"har-schema": "^2.0.0"
-			}
-		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3685,16 +3605,6 @@
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 				}
-			}
-		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
@@ -4300,11 +4210,6 @@
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-		},
 		"isurl": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
@@ -4344,11 +4249,6 @@
 				"esprima": "^4.0.0"
 			}
 		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-		},
 		"json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -4356,15 +4256,11 @@
 			"dev": true,
 			"optional": true
 		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -4384,17 +4280,6 @@
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
 			}
 		},
 		"jwt-simple": {
@@ -5222,11 +5107,6 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5633,11 +5513,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-		},
 		"picomatch": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -5734,11 +5609,6 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 			"dev": true
 		},
-		"psl": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-		},
 		"pstree.remy": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.7.tgz",
@@ -5757,7 +5627,8 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
 		},
 		"q": {
 			"version": "1.5.1",
@@ -5945,33 +5816,6 @@
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
 			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
 			"dev": true
-		},
-		"request": {
-			"version": "2.88.2",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.5.0",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			}
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -6553,22 +6397,6 @@
 				}
 			}
 		},
-		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
-		},
 		"stable": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -7100,15 +6928,6 @@
 				}
 			}
 		},
-		"tough-cookie": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-			"requires": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
-			}
-		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -7141,14 +6960,11 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type": {
 			"version": "1.2.0",
@@ -7367,6 +7183,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -7431,7 +7248,9 @@
 		"uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"dev": true,
+			"optional": true
 		},
 		"v8-compile-cache": {
 			"version": "2.1.0",
@@ -7458,16 +7277,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
-			}
 		},
 		"websocket": {
 			"version": "1.0.31",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1120,6 +1120,41 @@
 				"methods": "^1.1.2",
 				"qs": "^6.5.1",
 				"superagent": "^3.7.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"superagent": {
+					"version": "3.8.3",
+					"resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+					"integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+					"dev": true,
+					"requires": {
+						"component-emitter": "^1.2.0",
+						"cookiejar": "^2.1.0",
+						"debug": "^3.1.0",
+						"extend": "^3.0.0",
+						"form-data": "^2.3.1",
+						"formidable": "^1.2.0",
+						"methods": "^1.1.1",
+						"mime": "^1.4.1",
+						"qs": "^6.5.1",
+						"readable-stream": "^2.3.5"
+					}
+				}
 			}
 		},
 		"chalk": {
@@ -1403,8 +1438,7 @@
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-			"dev": true
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1501,8 +1535,7 @@
 		"cookiejar": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-			"integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-			"dev": true
+			"integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -2817,8 +2850,7 @@
 		"fast-safe-stringify": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-			"dev": true
+			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
 		},
 		"fd-slicer": {
 			"version": "1.1.0",
@@ -3018,8 +3050,7 @@
 		"formidable": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-			"integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
-			"dev": true
+			"integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -6733,37 +6764,70 @@
 			}
 		},
 		"superagent": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-			"integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
-			"dev": true,
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/superagent/-/superagent-5.2.2.tgz",
+			"integrity": "sha512-pMWBUnIllK4ZTw7p/UaobiQPwAO5w/1NRRTDpV0FTVNmECztsxKspj3ZWEordVEaqpZtmOQJJna4yTLyC/q7PQ==",
 			"requires": {
-				"component-emitter": "^1.2.0",
-				"cookiejar": "^2.1.0",
-				"debug": "^3.1.0",
-				"extend": "^3.0.0",
-				"form-data": "^2.3.1",
-				"formidable": "^1.2.0",
-				"methods": "^1.1.1",
-				"mime": "^1.4.1",
-				"qs": "^6.5.1",
-				"readable-stream": "^2.3.5"
+				"component-emitter": "^1.3.0",
+				"cookiejar": "^2.1.2",
+				"debug": "^4.1.1",
+				"fast-safe-stringify": "^2.0.7",
+				"form-data": "^3.0.0",
+				"formidable": "^1.2.1",
+				"methods": "^1.1.2",
+				"mime": "^2.4.4",
+				"qs": "^6.9.1",
+				"readable-stream": "^3.4.0",
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"requires": {
 						"ms": "^2.1.1"
 					}
 				},
+				"form-data": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+					"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.8",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"mime": {
+					"version": "2.4.4",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+					"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"qs": {
+					"version": "6.9.3",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+					"integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"multer": "~1.4.1",
 		"request": "*",
 		"streamifier": "^0.1.1",
+		"superagent": "^5.2.2",
 		"websocket": "^1.0.31"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"mongodb": "3.x.x",
 		"morgan": "1.9.1",
 		"multer": "~1.4.1",
-		"request": "*",
 		"streamifier": "^0.1.1",
 		"superagent": "^5.2.2",
 		"websocket": "^1.0.31"


### PR DESCRIPTION
Fixes #254

Replacing `Request` with `Superagent`.

Commit [14dd7](https://github.com/llaske/sugarizer-server/commit/14dd7cb01e282ea2baee1842b7cea8e9c68381e7) shows the modification we need to do to replace `request` with `superagent` in each file.

The changes are minimal.
- Both libraries use a callback function.
- HTTP Request Method, Headers and Query String can be set easily and the inside logic remains the same.
- Just have to replace `body` with `request.body` inside the function.

@llaske Should we go ahead with `Superagent` and remove `request` dependence completely?