### PR TITLE
Modifications to Mongo Url for kubernetes compatibility

### DIFF
--- a/config/wait4db.js
+++ b/config/wait4db.js
@@ -40,6 +40,6 @@ exports.waitConnection = function(settings, callback) {
 
 function createConnection(settings) {
 	return new mongo.MongoClient(
-		'mongodb://'+settings.database.server+':'+settings.database.port+'/'+settings.database.name,
+		(process.env.MONGO_URL || 'mongodb://'+settings.database.server+':'+settings.database.port)+'/'+settings.database.name,
 		{auto_reconnect: false, w:1, useNewUrlParser: true, useUnifiedTopology: true });
 }


### PR DESCRIPTION
In kubernetes deployment our sugarizer-server and mongodb containers will be in different pods.
Our service for mongodb pods will be assigned a DNS record for the following form
`<serviceName>.<namespace>.svc.cluster.local` which will be used to connect to the mongo pods.
I understand that this can be done by providing the DNS record in `database.server` of a new `kubernetes.ini` file having most values for most the properties same as `docker.ini` but the issue is that `serviceName` and `namespace` are not static strings and their values would have to be passed as environment variables in our pod manifest file. So passing a single environment variable `MONGO_URL` seems to be the least invasive and more simple approach.

A sample deployment on Google Kubernetes Engine incorporating changes in this PR can be accessed on - http://34.84.103.197:8080/

Details on how the env var will be passed in the deployment manifest file can found [here](https://github.com/ksraj123/sugarizer-server-k8s-ansible/blob/24a2630f7c61dfdcf8d17b4663e9cd4234cd063e/sugarizer-chart/templates/server_deployment.yaml#L40)