### PR TITLE
Handling sessions across multiple instances, kubernetes compatibility

### DIFF
--- a/config/main.js
+++ b/config/main.js
@@ -5,11 +5,12 @@ var express = require('express'),
 	logger = require('morgan'),
 	flash = require('express-flash'),
 	expressValidator = require('express-validator'),
-	cors = require('cors');
+	cors = require('cors'),
+	mongoStore = require('connect-mongo')(expressSession);
 var artificialDelay = 0;
 
 // configure app settings
-module.exports = function(app, ini) {
+module.exports = function(app, ini, db) {
 
 	// add an artificial delay for debug
 	if (artificialDelay) {
@@ -26,7 +27,10 @@ module.exports = function(app, ini) {
 			maxAge: parseInt(ini.security.max_age)
 		},
 		resave: true,
-		saveUninitialized: true
+		saveUninitialized: true,
+		store: new mongoStore({
+			db: db
+		})
 	}));
 
 	//include body parser

--- a/config/main.js
+++ b/config/main.js
@@ -10,7 +10,7 @@ var express = require('express'),
 var artificialDelay = 0;
 
 // configure app settings
-module.exports = function(app, ini, db) {
+module.exports = function(app, ini, client) {
 
 	// add an artificial delay for debug
 	if (artificialDelay) {
@@ -29,7 +29,7 @@ module.exports = function(app, ini, db) {
 		resave: true,
 		saveUninitialized: true,
 		store: new mongoStore({
-			db: db
+			client: client
 		})
 	}));
 

--- a/config/wait4db.js
+++ b/config/wait4db.js
@@ -16,8 +16,7 @@ exports.waitConnection = function(settings, callback) {
 			client.connect(function(err, client) {
 				if (!err) {
 					clearInterval(timer);
-					var db = client.db(settings.database.name);
-					callback(db);
+					callback(client);
 				} else {
 					console.log("Waiting for DB... ("+err.name+")");
 				}
@@ -29,8 +28,7 @@ exports.waitConnection = function(settings, callback) {
 		// Open the db
 		client.connect(function(err, client) {
 			if (!err) {
-				var db = client.db(settings.database.name);
-				callback(db);
+				callback(client);
 			} else {
 				callback();
 			}
@@ -40,6 +38,6 @@ exports.waitConnection = function(settings, callback) {
 
 function createConnection(settings) {
 	return new mongo.MongoClient(
-		'mongodb://'+settings.database.server+':'+settings.database.port+'/'+settings.database.name,
+		(process.env.MONGO_URL || 'mongodb://'+settings.database.server+':'+settings.database.port)+'/'+settings.database.name,
 		{auto_reconnect: false, w:1, useNewUrlParser: true, useUnifiedTopology: true });
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"license": "Apache-2.0",
 	"dependencies": {
 		"async": "2.6.1",
+		"connect-mongo": "^2.0.3",
 		"cookie-parser": "1.4.3",
 		"cors": "2.8.x",
 		"csv-parser": "~2.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"license": "Apache-2.0",
 	"dependencies": {
 		"async": "2.6.1",
-		"connect-mongo": "^2.0.3",
+		"connect-mongo": "^3.1.2",
 		"cookie-parser": "1.4.3",
 		"cors": "2.8.x",
 		"csv-parser": "~2.2.0",

--- a/sugarizer.js
+++ b/sugarizer.js
@@ -28,7 +28,7 @@ wait4db.waitConnection(ini, function(db) {
 	common.init(ini);
 
 	//configure app setting
-	require('./config/main')(app, ini);
+	require('./config/main')(app, ini, db);
 
 	// include api routes
 	require('./api/route')(app, ini, db);

--- a/sugarizer.js
+++ b/sugarizer.js
@@ -19,7 +19,8 @@ process.on("uncaughtException", function(err) {
 });
 
 // wait for database
-wait4db.waitConnection(ini, function(db) {
+wait4db.waitConnection(ini, function(client) {
+	var db = client.db(ini.database.name);
 	if (!db) {
 		console.log("Cannot connect with the database");
 		process.exit(-1);
@@ -28,7 +29,7 @@ wait4db.waitConnection(ini, function(db) {
 	common.init(ini);
 
 	//configure app setting
-	require('./config/main')(app, ini, db);
+	require('./config/main')(app, ini, client);
 
 	// include api routes
 	require('./api/route')(app, ini, db);


### PR DESCRIPTION
Fixes #262 

Since mongodb is already being used `connect-mongo` session store is used. This enables sessions to work across multiple instances and does not affect normal functionality.

@NikhilM98 @llaske The changes in this PR are not strictly related to sugarizer school portal as it is [not recommend](https://github.com/expressjs/session#sessionoptions) to use default `MemoryStore` as it is prone to memory leaks. Also, this issue will be apparent in any deployment scenario where there are more than 1 instance of sugarizer-server to whom requests can be routed to.

A deployment on Google Kubernetes Engine, incorporating changes in this PR with 3 instances of sugarizer-server can be accessed here for testing purposes - http://104.198.93.25:8080/dashboard/login
A default admin account has been added for testing purpose, 
username - defaultuser
password - password

![fixed session Peek 2020-04-14 21-05](https://user-images.githubusercontent.com/39027928/79243929-e5dd4f80-7e93-11ea-9a12-4e705fa972d7.gif)
