### PR TITLE
Fix server error flashing

### DIFF
--- a/dashboard/views/activities.ejs
+++ b/dashboard/views/activities.ejs
@@ -5,6 +5,7 @@
 		<%- include includes/navbar %>
 		<div class="content ">
 			<div class="container-fluid">
+				<% include includes/flash-errors %>
 				<div class="row" id="activities-list-parent">
 					<div class="col-md-12">
 						<div class="navbar-form navbar-right" style="display:flex; align-items:baseline;" id="activities-searchbox">

--- a/dashboard/views/admin/listCharts.ejs
+++ b/dashboard/views/admin/listCharts.ejs
@@ -5,6 +5,7 @@
 		<%- include ../includes/navbar %>
 		<div class="content ">
 			<div class="container-fluid">
+                <%- include ../includes/flash-errors %>
 				<div class="row">
                     <div class="col-md-12">
 						<div class="card">

--- a/dashboard/views/admin/stats.ejs
+++ b/dashboard/views/admin/stats.ejs
@@ -5,6 +5,7 @@
 	<%- include ../includes/navbar %>
 		<div class="content">
 			<div class="container-fluid">
+				<%- include ../includes/flash-errors %>
 				<div class="row">
 					<div class="col-md-12">
 						<div class="card">

--- a/dashboard/views/dashboard.ejs
+++ b/dashboard/views/dashboard.ejs
@@ -5,6 +5,7 @@
 	<%- include includes/navbar %>
 		<div class="content">
 			<div class="container-fluid">
+				<% include includes/flash-errors %>
 				<div class="row" id="dashboard-home-cards">
 					<div class="col-lg-3 col-md-3 col-sm-3">
 						<div class="card card-stats">


### PR DESCRIPTION
`flash-errors` was not included in some views where server popup is used due to which server popup is not displayed.

Steps to reproduce: When you try to Add/Edit/Delete a Chart, server popup will not be displayed.

Popup is displayed after applying the patch:
![Screenshot from 2020-04-15 00-55-53](https://user-images.githubusercontent.com/24666770/79266003-8fccd400-7eb4-11ea-9c59-fdf227b271da.png)
