### PR TITLE
Fix tutorial restart

### DIFF
--- a/dashboard/controller/classrooms/addClassroom.js
+++ b/dashboard/controller/classrooms/addClassroom.js
@@ -59,6 +59,7 @@ module.exports = function addClassroom(req, res) {
 		// send to classroom page
 		res.render('admin/addEditClassroom', {
 			module: 'classrooms',
+			mode: "add",
 			xocolors: xocolors,
 			moment: moment,
 			emoji: emoji,

--- a/dashboard/controller/classrooms/editClassroom.js
+++ b/dashboard/controller/classrooms/editClassroom.js
@@ -65,6 +65,7 @@ module.exports = function editClassroom(req, res) {
 						// send to classrooms page
 						res.render('admin/addEditClassroom', {
 							module: 'classrooms',
+							mode: "edit",
 							classroom: response.body,
 							moment: moment,
 							emoji: emoji,

--- a/dashboard/controller/stats/addChart.js
+++ b/dashboard/controller/stats/addChart.js
@@ -69,6 +69,7 @@ module.exports = function addChart(req, res) {
 		// send to stats page
 		res.render('admin/addEditChart', {
 			module: 'stats',
+			mode: "add",
 			moment: moment,
 			charts: chartList,
 			account: req.session.user,

--- a/dashboard/controller/stats/editChart.js
+++ b/dashboard/controller/stats/editChart.js
@@ -74,6 +74,7 @@ module.exports = function editChart(req, res) {
 						// send to stats page
 						res.render('admin/addEditChart', {
 							module: 'stats',
+							mode: "edit",
 							chart: response.body,
 							moment: moment,
 							charts: chartList,

--- a/dashboard/public/js/tutorial.js
+++ b/dashboard/public/js/tutorial.js
@@ -232,6 +232,7 @@ function sugarizerTour(currentView, role, mode) {
 
 	tutorial.restart = function() {
 		localStorage.setItem(tutorialName + "_current_step", 0);
+		localStorage.removeItem(tutorialName + "_end");
 		tutorial.start();
 	};
 

--- a/dashboard/public/js/tutorial.js
+++ b/dashboard/public/js/tutorial.js
@@ -1,9 +1,14 @@
 // Tutorial handling
 
-function sugarizerTour(currentView, role) {
+function sugarizerTour(currentView, role, mode) {
 	var tutorial = {};
 	var tour;
 	var launched = false;
+
+	var tutorialName = currentView;
+	if (mode) {
+		tutorialName = currentView + "_" + mode;
+	}
 
 	// Init tutorial
 	tutorial.init = function() {
@@ -11,7 +16,7 @@ function sugarizerTour(currentView, role) {
 		var nextString = document.webL10n.get("TutoNext");
 		var endString = document.webL10n.get("TutoEnd");
 		tour = new window.Tour({
-			name: currentView,
+			name: tutorialName,
 			template: "\
 			<div class='popover tour popover-tour'>\
 				<div class='arrow'></div>\
@@ -221,12 +226,12 @@ function sugarizerTour(currentView, role) {
 
 	// Check if already finished
 	tutorial.isFinished = function() {
-		if (window.localStorage[currentView + "_end"] == "yes") return true;
+		if (window.localStorage[tutorialName + "_end"] == "yes") return true;
 		return false;
 	};
 
 	tutorial.restart = function() {
-		localStorage.setItem(currentView + "_current_step", 0);
+		localStorage.setItem(tutorialName + "_current_step", 0);
 		tutorial.start();
 	};
 

--- a/dashboard/views/addEditUser.ejs
+++ b/dashboard/views/addEditUser.ejs
@@ -244,11 +244,6 @@ function show_user_fields(val) {
 }
 show_user_fields('<% if(typeof user == "object"){ %><%= user.role %><% } %>')
 
-var currTour = sugarizerTour("editUser", <% if (account.user && account.user.role=="admin") {"admin"} else {"teacher"} %>);
-if((typeof window.localStorage["view"] == 'undefined') || (window.localStorage["view"] == window.location.pathname)) {
-    if (!currTour.isFinished()) currTour.start();
-} else {
-    currTour.restart();
-}
-window.localStorage["view"] = window.location.pathname;
+var currTour = sugarizerTour("editUser", <% if (account.user && account.user.role=="admin") { %> "admin" <% } else { %> "teacher" <% } %>, "<%= mode %>");
+if (!currTour.isFinished()) currTour.start();
 </script>

--- a/dashboard/views/admin/addEditChart.ejs
+++ b/dashboard/views/admin/addEditChart.ejs
@@ -112,11 +112,6 @@
 
 
 <script>
-    var currTour = sugarizerTour("editChart", <% if (account.user && account.user.role=="admin") {"admin"} else {"teacher"} %>);
-    if((typeof window.localStorage["view"] == 'undefined') || (window.localStorage["view"] == window.location.pathname)) {
-        if (!currTour.isFinished()) currTour.start();
-    } else {
-        currTour.restart();
-    }
-    window.localStorage["view"] = window.location.pathname;
+    var currTour = sugarizerTour("editChart", <% if (account.user && account.user.role=="admin") { %> "admin" <% } else { %> "teacher" <% } %>, "<%= mode %>");
+    if (!currTour.isFinished()) currTour.start();
 </script>

--- a/dashboard/views/admin/addEditClassroom.ejs
+++ b/dashboard/views/admin/addEditClassroom.ejs
@@ -129,11 +129,6 @@
 <%- include ../includes/footer %>
 
 <script>
-    var currTour = sugarizerTour("editClassroom", <% if (account.user && account.user.role=="admin") {"admin"} else {"teacher"} %>);
-    if((typeof window.localStorage["view"] == 'undefined') || (window.localStorage["view"] == window.location.pathname)) {
-        if (!currTour.isFinished()) currTour.start();
-    } else {
-        currTour.restart();
-    }
-    window.localStorage["view"] = window.location.pathname;
+    var currTour = sugarizerTour("editClassroom", <% if (account.user && account.user.role=="admin") { %> "admin" <% } else { %> "teacher" <% } %>, "<%= mode %>");
+    if (!currTour.isFinished()) currTour.start();
 </script>


### PR DESCRIPTION
This PR fixes two issues:

First issue:
The tutorial for a view is supposed to run only one time when the user opens the view. If the user wants to view the tutorial again, they can click on the help button.

The tutorial for AddEditUser, AddEditClassroom and AddEditChart view keeps restarting without pressing the help button.

Steps to reproduce:
1. Clear Local Storage.
2. Open Add Classroom view. The tutorial runs automatically for the Add Classroom view.
3. Open Edit Classroom view. The tutorial runs automatically for the Edit Classroom view.
4. Open Add Classroom view again. The tutorial runs automatically for the Add Classroom view again. It is not supposed to run again automatically.

[42c098](https://github.com/llaske/sugarizer-server/commit/42c0987a8ac70a7c257523d668b8d139699ef333) fixes this issue.

Second issue:
When the tutorial is launched automatically (for the first visit in a view) and the user refreshes the page in between of the tutorial, the tutorial continues from the last step. However, when the user presses the Help button to launch the tutorial, the tutorial ends on page refresh.

[57759b](https://github.com/llaske/sugarizer-server/commit/57759bbdd59e062aa212f9ea71a3dab26400a1ba) fixes this issue.
