### PR TITLE
version for express-validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"express": "4.16.4",
 		"express-flash": "~0.0.2",
 		"express-session": "1.15.6",
-		"express-validator": "~5.3.1",
+		"express-validator": "5.3.1",
 		"http": "0.0.x",
 		"ini": "1.1.x",
 		"jwt-simple": "~0.5.1",


### PR DESCRIPTION
As stated in https://github.com/llaske/sugarizer-server/issues/187, iit's needed to change the version of express-validator in packages.json, to avoid error on sugarizer start (id use it with docker-compose install.