### PR TITLE
Fixed Permission error in install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ To run Sugarizer Server using Docker and Docker Compose:
 
 Install Docker Compose
 
-	curl -L "https://github.com/docker/compose/releases/download/1.8.1/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose
+	curl -L "https://github.com/docker/compose/releases/download/1.8.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 	chmod +x /usr/local/bin/docker-compose
 
 To install Docker Compose on ARM architectures (e.g. for the Raspberry Pi 3), the link above will not work.  You need to use [arm-compose](https://github.com/hypriot/arm-compose) instead.


### PR DESCRIPTION
Fixed #276 

Updated docker compose install command as given [here](https://docs.docker.com/compose/install/):
```
curl -L "https://github.com/docker/compose/releases/download/1.8.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
```
 