### PR TITLE
Issue fix #294: text align changed on Language selector

### DIFF
--- a/dashboard/public/css/main.css
+++ b/dashboard/public/css/main.css
@@ -240,6 +240,7 @@
   height: 30px;
   width: 120px;
   border-radius: 1000px;
+  text-align: center;
 }
 
 .pointer {


### PR DESCRIPTION
A same css change on the language selector 
![image](https://user-images.githubusercontent.com/57151177/158068365-36d1088a-70a1-46d1-b789-00065460cc62.png)

