### PR TITLE
Centered the divs inside list of Activities

### DIFF
--- a/dashboard/public/css/material-dashboard.css
+++ b/dashboard/public/css/material-dashboard.css
@@ -67,6 +67,10 @@ ol.simple_with_animation li .card .card-content div {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  height: 47px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 


### PR DESCRIPTION
Fix for the issue #351 

-- Detailed Fix -- 

- I have first set the height of divs equal to height of the list. (to finish that extra space below each div)
- Then using flexbox properties I have centered everything inside the div, height and width wise. 

![Screenshot 2023-02-10 at 4 04 44 PM](https://user-images.githubusercontent.com/54149585/218078068-c1df567a-5171-417b-962e-f70aa617caad.png)
