### PR TITLE
fixed sidebar logout option

### DIFF
--- a/dashboard/public/css/main.css
+++ b/dashboard/public/css/main.css
@@ -846,6 +846,12 @@
   display: none !important;
 }
 
+@media (max-width: 991px) {
+  .hide-desk-el {
+    display: block !important;
+  }
+}
+
 @media (max-width: 768px) {
   .pull-right-mobinterrupt {
     float: none !important;

--- a/dashboard/public/css/material-dashboard.css
+++ b/dashboard/public/css/material-dashboard.css
@@ -4827,6 +4827,7 @@ footer .btn {
   }
   .sidebar .nav-mobile-menu {
     margin-top: 0;
+    display: none;
   }
   .sidebar .nav-mobile-menu .notification {
     float: left;
@@ -4939,13 +4940,17 @@ footer .btn {
     content: "";
     z-index: 1;
   }
+  .sidebar .nav, .off-canvas-sidebar .nav {
+    margin-top: 0px;
+  }
   .sidebar .logo, .off-canvas-sidebar .logo {
     position: relative;
     z-index: 4;
   }
   .sidebar .navbar-form, .off-canvas-sidebar .navbar-form {
-    margin: 10px 15px;
+    margin: 10px 15px 0px;
     float: none !important;
+    box-shadow: none;
   }
   .sidebar .navbar-form .btn, .off-canvas-sidebar .navbar-form .btn {
     position: absolute;


### PR DESCRIPTION
Fix for the issue #348 

Changes I have made :- 

- Made the user dropdown for profile feature and logout feature "hidden" once the width is less than 992px.
- Made the logout button visible once it is under the width of 992px. (earlier it was only for less than 768px)
- Removed box shadow from language selector for much more cleaner look (because it was only there when the width was less than 768px and not 992px).
- Also reduced some margin between logout button and language selector for better experience.
Below I have attached a video of how it looks now.


https://user-images.githubusercontent.com/54149585/218292935-86fb2385-6ad9-4bfe-a4af-ee0d5ef856e7.mov

