### PR TITLE
Updated the popover box

### DIFF
--- a/dashboard/public/css/main.css
+++ b/dashboard/public/css/main.css
@@ -733,7 +733,7 @@
 }
 
 .icon-tutorial-text {
-	margin-top: 7px;
+	margin-top: 5px;
 	padding-left: 38px;
 	padding-right: 38px;
   display: inline-block;

--- a/dashboard/public/css/material-dashboard.css
+++ b/dashboard/public/css/material-dashboard.css
@@ -3381,6 +3381,7 @@ fieldset[disabled] .form-group.is-focused .togglebutton label {
   border: none;
   border-radius: 3px;
   box-shadow: 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12), 0 5px 5px -3px rgba(0, 0, 0, 0.2);
+  max-width: 300px;
 }
 
 .popover {
@@ -3395,12 +3396,12 @@ fieldset[disabled] .form-group.is-focused .togglebutton label {
 .popover-title {
   background-color: #FFFFFF;
   border: none;
-  padding: 15px 15px 5px;
-  font-size: 1.3em;
+  padding-left: 4px;
+  font-size: 17px;
 }
 
 .popover-content {
-  padding: 10px 15px 15px;
+  padding: 15px 15px 10px;
   line-height: 1.4;
 }
 
@@ -5171,4 +5172,31 @@ footer .btn {
     margin-left: -20px;
     margin-right: -20px;
   }
+}
+
+.title-icon-together{
+  display: flex;
+  flex-direction: row;
+  background-color: #808080;
+  justify-content: space-between;
+  align-items: center;
+  color: white;
+  padding: 0px 5px;
+  font-weight: 500;
+}
+
+#ease-title-selection {
+  display : flex;
+  align-self: center;
+  padding-left: 10px;
+  font-size: 14px;
+}
+
+/* overwriting the older settings for icon button */
+.title-icon-together .icon-button {
+  margin: 0px;
+}
+
+.title-icon-together .tutorial-end-icon{
+  width: auto;
 }

--- a/dashboard/public/js/tutorial.js
+++ b/dashboard/public/js/tutorial.js
@@ -20,7 +20,16 @@ function sugarizerTour(currentView, role, mode) {
 			template: "\
 			<div class='popover tour popover-tour'>\
 				<div class='arrow'></div>\
-				<h3 class='popover-title tutorial-title'></h3>\
+				<div class='title-icon-together'>\
+					<div id='ease-title-selection'>\
+						<div class='popover-title tutorial-title'></div>\
+					</div>\
+					<div class='tutorial-end-icon icon-button' data-role='end'>\
+						<div class='tutorial-end-icon1 web-activity'>\
+							<div class='tutorial-end-icon2 web-activity-icon'></div>\
+						</div>\
+					</div>\
+				</div>\
 				<table><tr><td style='vertical-align:top;'><div id='icon-tutorial' style='visibility:hidden;display:inline-block;'></div>\
 				</td><td><div class='popover-content'></div></td></tr></table>\
 				<div class='popover-navigation' style='display: flex; flex-wrap:wrap; justify-content: center; align-items: center'>\
@@ -31,20 +40,13 @@ function sugarizerTour(currentView, role, mode) {
 						</div>\
 						<div class='icon-tutorial-text'>"+ prevString + "</div>\
 					</div>\
-					<span data-role='separator' style='margin: 4px'>|</span>\
+					<span data-role='separator' style='margin: 4px; color : white'>|</span>\
 					<div class='tutorial-next-icon icon-button' data-role='next'>\
 						<div class='tutorial-next-icon1 web-activity'>\
 							<div class='tutorial-next-icon2 web-activity-icon'></div>\
 							<div class='tutorial-next-icon3 web-activity-disable'></div>\
 						</div>\
 						<div class='icon-tutorial-text'>"+ nextString + "</div>\
-					</div>\
-					<div class='tutorial-end-icon icon-button' data-role='end'>\
-						<div class='tutorial-end-icon1 web-activity'>\
-							<div class='tutorial-end-icon2 web-activity-icon'></div>\
-							<div class='tutorial-end-icon3 web-activity-disable'></div>\
-						</div>\
-						<div class='icon-tutorial-text'>"+ endString + "</div>\
 					</div>\
 				</div>\
 			</div>",


### PR DESCRIPTION
Fixes issue #360 

-- Detailed changes -- 

- Remove the end button from the bottom, and used only the cross-icon portion of it in the title.
- Written some extra divs and classes for adjusting title and icon in the same line.
- Written some extra css for styling the title div.
- Removed the dash between the prev and next by changing the color to white.
- Centered prev and next text by reducing some upper space.
- Reduced some space between button and contents.
- Increased the max-width from 276px to 300px of the box.



Before 
<img width="326" alt="Screenshot 2023-02-16 at 10 39 03 AM" src="https://user-images.githubusercontent.com/54149585/219289062-9611d137-585f-4d3f-b20b-11bf1f03d077.png">


After 
<img width="342" alt="Screenshot 2023-02-16 at 12 15 31 PM" src="https://user-images.githubusercontent.com/54149585/219288992-1c84ee10-5586-4ab8-82ee-ece25d9870a8.png">



