### PR TITLE
Refer to the MongoDB container in the migrate to v1.5.0 docs

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -46,7 +46,7 @@ First identify the id for the MongoDB container by running.
 docker ps
 ```
 
-The id is the one on the line named `sugarizer-server_server`.
+The id is the one on the line named `sugarizer-server_mongodb`.
 
 Now attach a bash shell on the running MongoDB instance by running:
 


### PR DESCRIPTION
I think that it was wanted to refer to the MongoDB container instead of the `server container. That's what what I did to successfully migrate from v1.3.0 to v1.5.0.