### PR TITLE
Add users filtering while exporting

### DIFF
--- a/dashboard/controller/users/exportCSV.js
+++ b/dashboard/controller/users/exportCSV.js
@@ -7,6 +7,11 @@ module.exports = function exportCSV(req, res) {
 	var users = [];
 	var Classrooms = {};
 
+	common.reinitLocale(req);
+	var selectedUsername = req.params.username;
+	var selectedRole = req.params.role;
+	var selectedClassroom = req.params.classroom; 
+
 	function validateUser(user) {
 		var validUser = {
 			_id: "",
@@ -173,11 +178,24 @@ module.exports = function exportCSV(req, res) {
 				});
 		}
 	], function() {
-		if (users.length == 0) {
-			res.json({success: false, msg: common.l10n.get('NoUsersFound')});
+		var filteredUsers = users.filter(function (user) {
+			var isRequired = true;
+			if (selectedUsername !== 'undefined' && user.name !== selectedUsername) {
+				isRequired = false;
+			}
+			if (isRequired && selectedRole !== 'all' && user.type !== selectedRole) {
+				isRequired = false;
+			}
+			if (isRequired && selectedRole === 'student' && selectedClassroom !== 'undefined' && selectedClassroom.split(',').indexOf(user._id) === -1) {
+				isRequired = false;
+			}
+			return isRequired;
+		});
+		if (filteredUsers.length === 0) {
+			res.json({ success: false, msg: common.l10n.get('NoUsersFound') });
 		} else {
-			res.json({success: true, msg: common.l10n.get('ExportSuccess'), data: users});
+			res.json({ success: true, msg: common.l10n.get('ExportSuccess'), data: filteredUsers });
 		}
-		return;
+		return;		  
 	});
 };

--- a/dashboard/route.js
+++ b/dashboard/route.js
@@ -40,6 +40,7 @@ module.exports = function (app, ini) {
 	app.post('/dashboard/users/add', authController.validateSession, usersController.addUser);
 	app.post('/dashboard/users/import', upload.single('file'), usersController.importCSV);
 	app.get('/dashboard/users/export', authController.validateSession, usersController.exportCSV);
+	app.get('/dashboard/users/export/:role/:username/:classroom', authController.validateSession, usersController.exportCSV);
 	app.get('/dashboard/users/edit/:uid', authController.validateSession, usersController.editUser);
 	app.post('/dashboard/users/edit/:uid', authController.validateSession, usersController.editUser);
 	app.get('/dashboard/users/delete/:uid', authController.validateSession, usersController.deleteUser);

--- a/dashboard/views/users.ejs
+++ b/dashboard/views/users.ejs
@@ -23,6 +23,7 @@
                                 <% if (account.user && account.user.role=="admin") { %>
                                 <option data-l10n-id="teacher" value="teacher" <% if(query.role=='teacher'){ %>selected="selected"<% } %> >Teacher</option>
                                 <option data-l10n-id="admin" value="admin" <% if(query.role=='admin'){ %>selected="selected"<% } %> >Admin</option>
+                                <option data-l10n-id="all" value="all" <% if(query.role=='all'){ %>selected="selected"<% } %> >All</option>
                                 <% } %>
                               </select>
 							  <script>$('#user-form [name="role"]').select2().on("change", () => show_class_fields())</script>
@@ -71,11 +72,16 @@
                                 <a href="#" onclick="deleteMultipleUsers(); return false;" class="btn btn-round" data-l10n-id="multidelete" title="Delete Multiple"><i class="material-icons text-muted">delete_forever</i></a>
                             </div>
                             <div class="btn pull-right btn-round" onclick="downloadUsers()" data-l10n-id="ExportUsers" id="users-exportusers">Export Users</div>
-                            <script>
+                            <script>                        
+                                var roleValue = document.getElementById('user-type-select2').value;
+                                var usernameValue = document.getElementById('username').value;
+                                var classroomValue = document.getElementById('classroom_select').value; 
+                                classroomValue = classroomValue == '' ? 'undefined' : classroomValue;                          
+                                usernameValue = usernameValue == '' ? 'undefined' : usernameValue;                            
                                 function downloadUsers(event) {
                                     $.ajax({
                                             type: "GET",
-                                            url: "/dashboard/users/export",
+                                            url: `/dashboard/users/export/${roleValue}/${usernameValue}/${classroomValue}`,
                                             success: function (res) {
                                                 if (res && res.success) {
                                                     var headers = {


### PR DESCRIPTION
Fixes issue #313 

I have taken motivation from last pull request on this issue.

- Now users can be exported on the basis of name, role and classrooms.
- 'All' option is added, using which all users can be exported.
- Instead of using parameters part of the URL, I have grouped them into query.
- Filtering logic is simplified.
- Misleading variable names are removed.
- Indentation is fixed.
- Used Array.filter for better logic representation.

This is an updated pull request for the requested changes. 

@llaske  @NikhilM98  Please review it and lemme know if any changes are required.