### PR TITLE
Feat: GH Issues and PR templates add

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: 🐛 Bug Report
+about: Report an issue to help us improve
+title: ""
+labels: ""
+assignees: ""
+---
+
+### Description
+
+<!-- A brief description with a link to the page on the site where you found the issue. -->
+
+### Expected Behavior
+
+<!-- A brief description of what you expected to happen. -->
+
+### Screenshots
+
+<!-- Add screenshots, if applicable, to help explain your problem. -->
+
+### Console log Errors:
+
+<!-- Upload console log screenshots to help explain your problem in much better fashion -->
+
+### Environment:
+
+- Operating System: [e.g., Windows, macOS, Linux]
+- Browser (if applicable): [e.g., Chrome, Firefox, Safari]
+- Version of Software/Project: [e.g., v1.0.0]
+
+### Checklist
+
+- [ ] I have read and followed the project's code of conduct.
+- [ ] I have searched for similar issues before creating this one.
+- [ ] I have provided all the necessary information to understand and reproduce the issue.
+- [ ] I am willing to contribute to the resolution of this issue.
+
+---
+
+Thank you for contributing to our project! We appreciate your help in improving it.
+
+📚 See [contributing instructions](https://github.com/llaske/sugarizer-server/tree/master/docs).
+
+🙋🏾🙋🏼 Questions: [Community Discord Server](https://discord.gg/p8UZyFtwHr).

--- a/.github/ISSUE_TEMPLATE/chore_task.md
+++ b/.github/ISSUE_TEMPLATE/chore_task.md
@@ -1,0 +1,30 @@
+---
+name: 🧹Chore or task
+about: Identify a necessary task to be addressed.
+title: ""
+labels: ""
+assignees: ""
+---
+
+### Current Behavior
+
+<!-- A brief description of what the current circumstance is. -->
+
+### Desired Situation
+
+<!-- A brief description of the necessary action to take. -->
+
+### Checklist
+
+- [ ] I have read and followed the project's code of conduct.
+- [ ] I have searched for similar issues before creating this one.
+- [ ] I have provided all the necessary information to understand and reproduce the issue.
+- [ ] I am willing to contribute to the resolution of this issue.
+
+---
+
+Thank you for contributing to our project! We appreciate your help in improving it.
+
+📚 See [contributing instructions](https://github.com/llaske/sugarizer-server/tree/master/docs).
+
+🙋🏾🙋🏼 Questions: [Community Discord Server](https://discord.gg/p8UZyFtwHr).

--- a/.github/ISSUE_TEMPLATE/ci.md
+++ b/.github/ISSUE_TEMPLATE/ci.md
@@ -1,0 +1,40 @@
+---
+name: 🛠 Continuous Integration / DevOps
+about: Improve or update workflows or other automation
+title: "[CI]"
+labels: ""
+assignees: ""
+---
+
+#### Current Behavior
+
+<!-- A brief description of what the problem is. (e.g. I need to be able to...) -->
+
+#### Desired Behavior
+
+<!-- A brief description of what you expected to happen. -->
+
+#### Implementation
+
+<!-- Specifics on the approach to fulfilling the feature request. -->
+
+#### Acceptance Tests
+
+<!-- Stipulations of functional behavior or non-functional items that must be in-place in order for the issue to be closed. -->
+
+---
+
+### Checklist
+
+- [ ] I have read and followed the project's code of conduct.
+- [ ] I have searched for similar issues before creating this one.
+- [ ] I have provided all the necessary information to understand and reproduce the issue.
+- [ ] I am willing to contribute to the resolution of this issue.
+
+---
+
+Thank you for contributing to our project! We appreciate your help in improving it.
+
+📚 See [contributing instructions](https://github.com/llaske/sugarizer-server/tree/master/docs).
+
+🙋🏾🙋🏼 Questions: [Community Discord Server](https://discord.gg/p8UZyFtwHr).

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,32 @@
+---
+name: 📄 Documentation issue
+about: Issues related to documentation.
+title: "[Docs]"
+labels: ""
+assignees: ""
+---
+
+#### Current State
+
+<!-- A brief description of what the current circumstance is. -->
+
+#### Desired State
+
+<!-- A brief description of the necessary action to take. -->
+
+---
+
+### Checklist
+
+- [ ] I have read and followed the project's code of conduct.
+- [ ] I have searched for similar issues before creating this one.
+- [ ] I have provided all the necessary information to understand and reproduce the issue.
+- [ ] I am willing to contribute to the resolution of this issue.
+
+---
+
+Thank you for contributing to our project! We appreciate your help in improving it.
+
+📚 See [contributing instructions](https://github.com/llaske/sugarizer-server/tree/master/docs).
+
+🙋🏾🙋🏼 Questions: [Community Discord Server](https://discord.gg/p8UZyFtwHr).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,52 @@
+---
+name: 💡 Feature request
+about: Suggest an enhancement
+title: ""
+labels: ""
+assignees: ""
+---
+
+### Current Behavior
+
+<!-- A brief description of what the problem is. (e.g. I need to be able to...) -->
+
+### Desired Behavior
+
+<!-- A brief description of the enhancement. -->
+
+### Screenshots / Mockups
+
+<!-- Add any other context or screenshots about the feature request here. -->
+
+### Implementation
+
+<!-- Specifics on the approach to fulfilling the feature request. -->
+
+### Acceptance Tests
+
+<!-- Stipulations of functional behavior or non-functional items that must be in-place in order for the issue to be closed. -->
+
+### Environment
+
+- Operating System: [e.g., Windows, macOS, Linux]
+- Browser (if applicable): [e.g., Chrome, Firefox, Safari]
+- Version of Software/Project: [e.g., v1.0.0]
+
+### Additional Information
+
+<!-- [Include any additional context, logs, or details that might be helpful in addressing the issue.] -->
+
+### Checklist
+
+- [ ] I have read and followed the project's code of conduct.
+- [ ] I have searched for similar issues before creating this one.
+- [ ] I have provided all the necessary information to understand and reproduce the issue.
+- [ ] I am willing to contribute to the resolution of this issue.
+
+---
+
+Thank you for contributing to our project! We appreciate your help in improving it.
+
+📚 See [contributing instructions](https://github.com/llaske/sugarizer-server/tree/master/docs).
+
+🙋🏾🙋🏼 Questions: [Community Discord Server](https://discord.gg/p8UZyFtwHr).

--- a/.github/PULL_REQUEST_TEMPLATE/generic.md
+++ b/.github/PULL_REQUEST_TEMPLATE/generic.md
@@ -1,0 +1,59 @@
+---
+name: Pull Request
+about: Submit changes to the project for review and inclusion
+---
+
+## Description
+
+<!--- Describe the changes introduced by this pull request. -->
+<!--- Explain what problem it solves or what feature/fix it adds. -->
+
+## Related Issue
+
+<!--- If this pull request is related to a specific issue, reference it here using #issue_number. -->
+<!--- For example, "Fixes #123" or "Addresses #456". -->
+
+This PR fixes #
+
+## Changes Made
+
+<!--- Provide a summary of the changes made in this pull request. -->
+<!--- Include any relevant technical details or architecture changes. -->
+
+- Change 1
+- Change 2
+- ...
+
+## Testing Performed
+
+<!--- Describe the testing that you have performed to validate these changes. -->
+<!--- Include information about test cases, testing environments, and results. -->
+
+- Tested feature X in scenario Y.
+- Ran unit tests for component Z.
+- Tested on browsers A, B, and C.
+- ...
+
+## Checklist
+
+<!--- Please check the boxes that apply to this pull request. -->
+<!--- You can add or remove items as needed. -->
+
+- [ ] I have tested these changes locally and they work as expected.
+- [ ] I have added/updated tests that prove the effectiveness of these changes.
+- [ ] I have updated the documentation to reflect these changes, if applicable.
+- [ ] I have followed the project's coding style guidelines.
+- [ ] I have addressed the code review feedback from the previous submission, if applicable.
+
+## Additional Notes for Reviewers
+
+<!--- Provide any additional context or notes for the reviewers. -->
+<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->
+
+---
+
+Thank you for contributing to our project! We appreciate your help in improving it.
+
+📚 See [contributing instructions](https://github.com/llaske/sugarizer-server/tree/master/docs).
+
+🙋🏾🙋🏼 Questions: [Community Discord Server](https://discord.gg/p8UZyFtwHr).


### PR DESCRIPTION
### Description: 

- Added a few standard issue ticket templates when anyone creates a new GH issue.  This PR fixes #408 

✅ **Added Issue templates for:**
 
1. Bug Report
2. Feature Request
3. Chore task
4. Continuous Integration (CI) DevOps task
5. Documentation task

✅  **Added PR template** 

### Impact of this PR:

- Any new/existing contributor who creates an issue ticket, will cover all the potential points without missing anything. I have seen in a few orgs that people often misses out on adding "descriptive" content in the issue raised. And then gets follow up questions on that reported issue.
- To save time for maintainers who assigns issue to contributors, this will be quite helpful.
